### PR TITLE
Patch for inet_tls_dist: do not pass SNI if address is raw IP

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -93,10 +93,14 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 		    ?trace("port_please(~p) -> version ~p~n", 
 			   [Node,Version]),
 		    dist_util:reset_timer(Timer),
+            IsHostname = case inet:parse_address(Address) of
+                             {ok, _} -> false;
+                             _ -> true
+                         end,
 		    case
                         ssl_tls_dist_proxy:connect(
-                          Driver, Address, TcpPort,
-                          [{server_name_indication, Address}])
+                          Driver, Ip, TcpPort,
+                          [{server_name_indication, Address} || IsHostname])
                     of
 			{ok, Socket} ->
 			    HSData = connect_hs_data(Kernel, Node, MyNode, Socket, 


### PR DESCRIPTION
In order to establish tls connection using raw IP address with
server name verification enabled we should not use SNI and pass
connect address as a tuple instead of string. My understanding
is that it tries to verify it as a hostname otherwise.