### PR TITLE
MB-37420: Match wildcards in subjectAltNames

### DIFF
--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1483,11 +1483,11 @@ verify_hostname_match_default(Ref, Pres) ->
 verify_hostname_match_default0(FQDN=[_|_], {cn,FQDN}) -> 
     not lists:member($*, FQDN);
 verify_hostname_match_default0(FQDN=[_|_], {cn,Name=[_|_]}) -> 
-    [F1|Fs] = string:tokens(FQDN, "."),
-    [N1|Ns] = string:tokens(Name, "."),
-    match_wild(F1,N1) andalso Fs==Ns;
-verify_hostname_match_default0({dns_id,R}, {dNSName,P}) ->
-    R==P;
+    verify_hostname_match_wildcard(FQDN, Name);
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,FQDN}) ->
+    not lists:member($*, FQDN);
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,Name=[_|_]}) ->
+    verify_hostname_match_wildcard(FQDN, Name);
 verify_hostname_match_default0({uri_id,R}, {uniformResourceIdentifier,P}) ->
     R==P;
 verify_hostname_match_default0({ip,R}, {iPAddress,P}) when length(P) == 4 ->
@@ -1519,6 +1519,11 @@ verify_hostname_match_default0({srv_id,R}, {?srvName_OID,P}) ->
     R==P;
 verify_hostname_match_default0(_, _) ->
     false.
+
+verify_hostname_match_wildcard(FQDN, Name) ->
+    [F1|Fs] = string:tokens(FQDN, "."),
+    [N1|Ns] = string:tokens(Name, "."),
+    match_wild(F1,N1) andalso Fs==Ns.
 
 ok({ok,X}) -> X.
 


### PR DESCRIPTION
https://github.com/erlang/otp/pull/1667

After internal discussion it was decided we need to enable wildcards
in SAN for Mad-Hatter hence the patch for erlang 20.

Erlang team added an option customize_hostname_check to enable SAN
wildcards in erlang 21 but we decided not to backport their
solution because of the following reasons:
- the patch would become more complex and more risky;
- appling soultion from otp team would require extra work to be done
  in order to enable SAN wildcards for distribution (because they
  only provide an option, so distribution needs to start using this
  option);
- we will have to fix other then distribution clients that we use as
  well (mostly http clients I guess).

Related OTP commits:
https://github.com/erlang/otp/commit/f821c91cebe0cee22c1c6e0a9dfe45d4e9b5f129
https://github.com/erlang/otp/commit/66ed8bc404d56cf7277ac34226a8d605740f492e

When we migrate to erlang 21 or higher we need to reevaluate the
option of using of the otp team fix. I suspect it might be still
easier to just reapply this patch though.