### PR TITLE
[Backport] memsup: Return correct amount of total system memory on macOS

### DIFF
--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -175,7 +175,7 @@ init([]) ->
 
     OS = os:type(),
     PortMode = case OS of
-		   {unix, darwin} -> false;
+		   {unix, darwin} -> true;
 		   {unix, freebsd} -> false;
 		   {unix, dragonfly} -> false;
 		   % Linux supports this.
@@ -725,22 +725,6 @@ reply(Pending, MemUsage, SysMemUsage) ->
 
 %% get_memory_usage(OS) -> {Alloc, Total}
 
-%% Darwin:
-%% Uses vm_stat command.
-get_memory_usage({unix,darwin}) ->
-    Str1 = os:cmd("/usr/bin/vm_stat"),
-    PageSize = 4096,
-
-    {[Free],        Str2} = fread_value("Pages free:~d.", Str1),
-    {[Active],      Str3} = fread_value("Pages active:~d.", Str2),
-    {[Inactive],    Str4} = fread_value("Pages inactive:~d.", Str3),
-    {[Speculative], Str5} = fread_value("Pages speculative:~d.", Str4),
-    {[Wired],       _} = fread_value("Pages wired down:~d.", Str5),
-
-    NMemUsed  = (Wired + Active + Inactive) * PageSize,
-    NMemTotal = NMemUsed + (Free + Speculative) * PageSize,
-    {NMemUsed,NMemTotal};
-
 %% FreeBSD: Look in /usr/include/sys/vmmeter.h for the format of struct
 %% vmmeter
 get_memory_usage({unix,OSname}) when OSname == freebsd; OSname == dragonfly ->
@@ -760,16 +744,6 @@ get_memory_usage({win32,_OSname}) ->
 	io_lib:fread("~d~d~d~d~d~d~d", Result),
     {TotPhys-AvailPhys, TotPhys}.
 
-fread_value(Format, Str0) ->
-    case io_lib:fread(Format, skip_to_eol(Str0)) of
-    	{error, {fread, input}} -> {[0], Str0};
-	{ok, Value, Str1} -> {Value, Str1}
-    end.
-
-skip_to_eol([]) -> [];
-skip_to_eol([$\n | T]) -> T;
-skip_to_eol([_ | T]) -> skip_to_eol(T).
-
 freebsd_sysctl(Def) ->
     list_to_integer(os:cmd("/sbin/sysctl -n " ++ Def) -- "\n").
 
@@ -787,9 +761,6 @@ get_ext_memory_usage(OS, {Alloc, Total}) ->
 	    [{total_memory, Total}, {free_memory, Total-Alloc},
 	     {system_total_memory, Total}];
 	{unix, dragonfly} ->
-	    [{total_memory, Total}, {free_memory, Total-Alloc},
-	     {system_total_memory, Total}];
-	{unix, darwin} ->
 	    [{total_memory, Total}, {free_memory, Total-Alloc},
 	     {system_total_memory, Total}];
 	_ -> % OSs using a port


### PR DESCRIPTION
On macOS, `memsup:get_system_memory_data/0` and `memsup:get_memory_data/0` returns
a much too low number for the amount system memory.

The bug is in a function that tried to determine the amount of memory by summing
numbers from the output of the `vm_stat` command.

Instead of trying to fix the summation, we will change approach and use the port
program to retrieve the information. Using the Mach APIs the total amount of memory
can be retrieved directly without any summing.

https://bugs.erlang.org/browse/ERL-1327