### PR TITLE
MB-45793 io_lib:format/3 with chars_limit opt on loops on some terms

### DIFF
--- a/lib/stdlib/src/io_lib_pretty.erl
+++ b/lib/stdlib/src/io_lib_pretty.erl
@@ -612,7 +612,7 @@ print_length_map_pairs(Term, D, D0, T, RF, Enc, Str) when D =:= 1; T =:= 0->
            end,
     {dots, 3, 3, More};
 print_length_map_pairs({K, V, Iter}, D, D0, T, RF, Enc, Str) ->
-    Pair1 = print_length_map_pair(K, V, D0, tsub(T, 1), RF, Enc, Str),
+    Pair1 = print_length_map_pair(K, V, D0, T, RF, Enc, Str),
     {_, Len1, _, _} = Pair1,
     Next = maps:next(Iter),
     [Pair1 |
@@ -641,9 +641,8 @@ print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
     {dots, 3, 3, More};
 print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) ->
     E = element(I, Tuple),
-    T1 = tsub(T, 1),
-    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str),
-    T2 = tsub(T1, Len1),
+    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T, RF, Enc, Str),
+    T2 = tsub(T, Len1+1),
     [Elem1 | print_length_tuple1(Tuple, I + 1, D - 1, T2, RF, Enc, Str)].
 
 print_length_record(Tuple, 1, _T, RF, RDefs, Enc, Str) ->
@@ -695,7 +694,7 @@ print_length_list1(Term, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
     More = fun(T1, Dd) -> ?FUNCTION_NAME(Term, D+Dd, T1, RF, Enc, Str) end,
     {dots, 3, 3, More};
 print_length_list1([E | Es], D, T, RF, Enc, Str) ->
-    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, tsub(T, 1), RF, Enc, Str),
+    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T, RF, Enc, Str),
     [Elem1 | print_length_list1(Es, D - 1, tsub(T, Len1 + 1), RF, Enc, Str)];
 print_length_list1(E, D, T, RF, Enc, Str) ->
     print_length(E, D - 1, T, RF, Enc, Str).
@@ -926,7 +925,7 @@ expand_list(Ifs, T, Dd, L0) ->
 expand_list([], _T, _Dd) ->
     [];
 expand_list([If | Ifs], T, Dd) ->
-    {_, Len1, _, _} = Elem1 = expand(If, tsub(T, 1), Dd),
+    {_, Len1, _, _} = Elem1 = expand(If, T, Dd),
     [Elem1 | expand_list(Ifs, tsub(T, Len1 + 1), Dd)];
 expand_list({_, _, _, More}, T, Dd) ->
     More(T, Dd).


### PR DESCRIPTION
The bug is in the function io_lib_pretty:intermediate/6 which is called by io_lib:format/3.

The algorithm in intermediate/6 works as follow:
1) Start with: an initial Depth D0 = 1, number of chars needed to print the term L=0.
2) Walk the term until depth D0, and update L.
3) If L < chars_limit, update D0 = 2*D0. And repeat from step 1.
4) If L > chars_limit, returned the trimmed term.

Due to a bug, L is always less than chars_limit and we end up in a loop.

L in step 2 is computed by io_lib_pretty:find_upper, using an auxiliary
length T. The bug is in the computation of T, specifically for nest List
terms like, [1000,[999,[998 ...]]].

This works in the all the three basic terms we initially encountered loops in: 
f(F), F = fun F(I) -> case I =:= 0 of true -> [0]; false -> [I, F(I-1)] end end.
f(F), F = fun R(I) -> case I =:= 0 of true -> 0; false -> {I, R(I-1)} end end.
f(F), F = fun R(I) -> case I =:= 0 of true -> 0; false -> #{I => R(I-1)} end end.