### PR TITLE
MB-45793 io_lib:format/3 with chars_limit opt on some terms falls int…

### DIFF
--- a/lib/stdlib/src/io_lib_pretty.erl
+++ b/lib/stdlib/src/io_lib_pretty.erl
@@ -612,11 +612,15 @@ print_length_map_pairs(Term, D, D0, T, RF, Enc, Str) when D =:= 1; T =:= 0->
            end,
     {dots, 3, 3, More};
 print_length_map_pairs({K, V, Iter}, D, D0, T, RF, Enc, Str) ->
-    Pair1 = print_length_map_pair(K, V, D0, tsub(T, 1), RF, Enc, Str),
-    {_, Len1, _, _} = Pair1,
     Next = maps:next(Iter),
+    T1 = case Next =:= none of
+             false -> tsub(T,1);
+             true -> T
+         end,
+    Pair1 = print_length_map_pair(K, V, D0, T1, RF, Enc, Str),
+    {_, Len1, _, _} = Pair1,
     [Pair1 |
-     print_length_map_pairs(Next, D - 1, D0, tsub(T, Len1+1), RF, Enc, Str)].
+     print_length_map_pairs(Next, D - 1, D0, tsub(T1, Len1), RF, Enc, Str)].
 
 print_length_map_pair(K, V, D, T, RF, Enc, Str) ->
     {_, KL, KD, _} = P1 = print_length(K, D, T, RF, Enc, Str),
@@ -641,7 +645,10 @@ print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
     {dots, 3, 3, More};
 print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) ->
     E = element(I, Tuple),
-    T1 = tsub(T, 1),
+    T1 = case I =:= tuple_size(Tuple) of
+             false -> tsub(T,1);
+             true -> T
+         end,
     {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str),
     T2 = tsub(T1, Len1),
     [Elem1 | print_length_tuple1(Tuple, I + 1, D - 1, T2, RF, Enc, Str)].
@@ -670,7 +677,10 @@ print_length_fields(Term, D, T, Tuple, I, RF, Enc, Str)
     {dots, 3, 3, More};
 print_length_fields([Def | Defs], D, T, Tuple, I, RF, Enc, Str) ->
     E = element(I, Tuple),
-    T1 = tsub(T, 1),
+    T1 = case I =:= tuple_size(Tuple) of
+             false -> tsub(T,1);
+             true -> T
+         end,
     Field1 = print_length_field(Def, D - 1, T1, E, RF, Enc, Str),
     {_, Len1, _, _} = Field1,
     T2 = tsub(T1, Len1),
@@ -695,8 +705,13 @@ print_length_list1(Term, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
     More = fun(T1, Dd) -> ?FUNCTION_NAME(Term, D+Dd, T1, RF, Enc, Str) end,
     {dots, 3, 3, More};
 print_length_list1([E | Es], D, T, RF, Enc, Str) ->
-    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, tsub(T, 1), RF, Enc, Str),
-    [Elem1 | print_length_list1(Es, D - 1, tsub(T, Len1 + 1), RF, Enc, Str)];
+    %% If E is the last element in list, don't account length for a comma.
+    T1 = case Es =:= [] of
+             false -> tsub(T,1);
+             true -> T
+         end,
+    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str),
+    [Elem1 | print_length_list1(Es, D - 1, tsub(T1, Len1), RF, Enc, Str)];
 print_length_list1(E, D, T, RF, Enc, Str) ->
     print_length(E, D - 1, T, RF, Enc, Str).
 
@@ -926,8 +941,12 @@ expand_list(Ifs, T, Dd, L0) ->
 expand_list([], _T, _Dd) ->
     [];
 expand_list([If | Ifs], T, Dd) ->
-    {_, Len1, _, _} = Elem1 = expand(If, tsub(T, 1), Dd),
-    [Elem1 | expand_list(Ifs, tsub(T, Len1 + 1), Dd)];
+    T1 = case Ifs =:= [] of
+             false -> tsub(T,1);
+             true -> T
+         end,
+    {_, Len1, _, _} = Elem1 = expand(If, T1, Dd),
+    [Elem1 | expand_list(Ifs, tsub(T1, Len1), Dd)];
 expand_list({_, _, _, More}, T, Dd) ->
     More(T, Dd).
 


### PR DESCRIPTION
…o a loop

**Describe the bug**
For specific nested terms and chars_limit, like the one mentioned below io_lib:format/3 falls into a loop. 
**To Reproduce**
```
1> f(F), F = fun R(I) -> case I =:= 0 of true -> 0; false -> [I, R(I-1)] end end.
#Fun<erl_eval.31.126501267>
2> io_lib:format("~p", [F(1000)], [{chars_limit, 1000}]). 
```
Similar bugs exists for nested tuples and nested maps. 
```
f(F), F = fun R(I) -> case I =:= 0 of true -> 0; false -> {I, R(I-1)} end end.
f(F), F = fun R(I) -> case I =:= 0 of true -> 0; false -> #{I => R(I-1)} end end.
```
**Expected behavior**
The list should be trimmed, to print the term until the soft limit of chars_limit is printed.
**Affected versions**
Tested in on the following version - Erlang/OTP 22 [erts-10.7.2.7] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]
**Additional context**t
The bug is this - when you have a tail-nested term like, {1,{2,{3 ...}}}} we reserve space for a comma even for the tail element (in line 698) which will never be used. I think there should be stronger checks to check if E is a tail element or not and only then decrement T by 1 and not decrement T at all in line 699.

And therefore in the function clause:
`print_length_list1(Term, D, T, RF, Enc, Str) when D =:= 1; T =:= 0
` when T =:= 0 and the walk terminates, the Length accumulated in Len via list_length (in print_length_list) is less than chars_limit.

Now, In find_upper (on finding Len < T) we exponentially keep increasing the depth and end up looping.

Find outputs from examples runs here - https://gist.github.com/hareen-kancharla/43480e5070a2a8c7498be69e18cfe644
