### PR TITLE
otp 23.3.4.5 for NEO

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -11,7 +11,7 @@
 %%% --------------------------------------------------------------------
 -vc('$Id$ ').
 -export([open/1, open/2,
-	 simple_bind/3, simple_bind/4,
+	 simple_bind/3, simple_bind/4, sasl_external_bind/1,
 	 controlling_process/2,
 	 start_tls/2, start_tls/3, start_tls/4,
          modify_password/3, modify_password/4, modify_password/5,
@@ -165,6 +165,10 @@ simple_bind(Handle, Dn, Passwd) when is_pid(Handle)  ->
 
 simple_bind(Handle, Dn, Passwd, Controls) when is_pid(Handle)  ->
     send(Handle, {simple_bind, Dn, Passwd, Controls}),
+    recv(Handle).
+
+sasl_external_bind(Handle) ->
+    send(Handle, {sasl_external_bind, asn1_NOVALUE}),
     recv(Handle).
 
 %%% --------------------------------------------------------------------
@@ -549,6 +553,11 @@ loop(Cpid, Data) ->
 	    send(From,Res),
 	    ?MODULE:loop(Cpid, NewData);
 
+        {From, {sasl_external_bind, Controls}} ->
+            {Res, NewData} = do_sasl_external_bind(Data, Controls),
+            send(From, Res),
+            ?MODULE:loop(Cpid, NewData);
+
 	{From, {cnt_proc, NewCpid}} ->
 	    unlink(Cpid),
 	    send(From,ok),
@@ -665,6 +674,43 @@ exec_extended_req_reply(_, Error) ->
 %%% --------------------------------------------------------------------
 %%% bindRequest
 %%% --------------------------------------------------------------------
+
+do_sasl_external_bind(Data, Controls) ->
+    case catch exec_sasl_external_bind(Data#eldap{id = bump_id(Data)},
+                                       Controls) of
+        {ok, NewData} -> {ok, NewData};
+        {{ok, Val}, NewData} -> {{ok, Val}, NewData};
+        {error, Emsg} -> {{error, Emsg}, Data};
+        Else -> {{error,Else},Data}
+    end.
+
+exec_sasl_external_bind(Data, Controls) ->
+    Creds = #'SaslCredentials'{mechanism = "EXTERNAL", credentials = ""},
+    Req = #'BindRequest'{version = Data#eldap.version,
+                         name = Data#eldap.binddn,
+                         authentication = {sasl, Creds}},
+    log2(Data, "bind request = ~p~n", [Req]),
+    Reply = request(Data#eldap.fd, Data, Data#eldap.id,
+                    {bindRequest, Req, Controls}),
+    log2(Data, "bind reply = ~p~n", [Reply]),
+    exec_sasl_external_bind_reply(Data, Reply).
+
+exec_sasl_external_bind_reply(Data, {ok, Msg}) when
+                            Msg#'LDAPMessage'.messageID == Data#eldap.id ->
+    case Msg#'LDAPMessage'.protocolOp of
+        {bindResponse, Result} ->
+            case Result#'BindResponse'.resultCode of
+                success ->
+                    {ok, Data};
+                referral ->
+                    {{ok, {referral,Result#'BindResponse'.referral}}, Data};
+                Error  ->
+                    {error, Error}
+            end;
+        Other -> {error, Other}
+    end;
+exec_sasl_external_bind_reply(_, Error) ->
+    {error, Error}.
 
 %%% Authenticate ourselves to the directory using
 %%% simple authentication.

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -709,7 +709,12 @@ send_challenge(#hs_data{socket = Socket, this_node = Node,
 
         ?DFLAG_HANDSHAKE_23 ->
             %% Reply with new 'N' message
-            Creation = erts_internal:get_creation(),
+            Creation = case erts_internal:get_creation() of
+                           undefined ->
+                               0;
+                           N ->
+                               N
+                       end,
             NodeName = atom_to_binary(Node, latin1),
             NameLen = byte_size(NodeName),
             ?trace("send: 'N' challenge=~w creation=~w\n",

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -45,11 +45,11 @@
 -export([start/0, start_link/0, stop/0,
          port_please/2, port_please/3, listen_port_please/2,
          names/0, names/1,
-	 register_node/2, register_node/3, address_please/3, open/0, open/1, open/2]).
+   register_node/2, register_node/3, address_please/3, open/0, open/1, open/2]).
 
 %% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, 
-	 terminate/2, code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+   terminate/2, code_change/3]).
 
 -import(lists, [reverse/1]).
 
@@ -81,22 +81,21 @@ stop() ->
 %% return {port, P, Version} | noport
 %%
 
--spec port_please(Name, Host) -> {ok, Port, Version} | noport | closed | {error, term()} when
-	  Name :: atom() | string(),
-	  Host :: atom() | string() | inet:ip_address(),
-	  Port :: non_neg_integer(),
-	  Version :: non_neg_integer().
+-spec port_please(Name, Host) -> {port, Port, Version} | noport when
+    Name :: atom() | string(),
+    Host :: atom() | string() | inet:ip_address(),
+    Port :: non_neg_integer(),
+    Version :: non_neg_integer().
 
 port_please(Node, Host) ->
   port_please(Node, Host, infinity).
 
--spec port_please(Name, Host, Timeout) -> {port, Port, Version} | noport | closed | {error, term()} when
-	  Name :: atom() | string(),
-	  Host :: atom() | string() | inet:ip_address(),
-	  Timeout :: non_neg_integer() | infinity,
-	  Port :: non_neg_integer(),
-	  Version :: non_neg_integer().
-
+-spec port_please(Name, Host, Timeout) -> {port, Port, Version} | noport when
+    Name :: atom() | string(),
+    Host :: atom() | string() | inet:ip_address(),
+    Timeout :: non_neg_integer() | infinity,
+    Port :: non_neg_integer(),
+    Version :: non_neg_integer().
 port_please(Node, HostName, Timeout) ->
     case listen_port_please(Node, HostName) of
         {ok, 0} ->
@@ -147,9 +146,9 @@ listen_port_please(_Name, _Host) ->
     end.
 
 -spec names() -> {ok, [{Name, Port}]} | {error, Reason} when
-	  Name :: string(),
-	  Port :: non_neg_integer(),
-	  Reason :: address | file:posix().
+    Name :: string(),
+    Port :: non_neg_integer(),
+    Reason :: address | file:posix().
 
 names() ->
     {ok, H} = inet:gethostname(),
@@ -170,20 +169,20 @@ names(HostName) ->
     end.
 
 -spec register_node(Name, Port) -> Result when
-	  Name :: string(),
-	  Port :: non_neg_integer(),
-	  Creation :: non_neg_integer(),
-	  Result :: {ok, Creation} | {error, already_registered} | term().
+    Name :: string(),
+    Port :: non_neg_integer(),
+    Creation :: non_neg_integer(),
+    Result :: {ok, Creation} | {error, already_registered} | term().
 
 register_node(Name, PortNo) ->
-	register_node(Name, PortNo, inet).
+  register_node(Name, PortNo, inet).
 
 -spec register_node(Name, Port, Driver) -> Result when
-	  Name :: string(),
-	  Port :: non_neg_integer(),
-	  Driver :: inet_tcp | inet6_tcp | inet | inet6,
-	  Creation :: non_neg_integer() | -1,
-	  Result :: {ok, Creation} | {error, already_registered} | term().
+    Name :: string(),
+    Port :: non_neg_integer(),
+    Driver :: inet_tcp | inet6_tcp | inet | inet6,
+    Creation :: non_neg_integer() | -1,
+    Result :: {ok, Creation} | {error, already_registered} | term().
 
 register_node(Name, PortNo, inet_tcp) ->
     register_node(Name, PortNo, inet);
@@ -193,12 +192,12 @@ register_node(Name, PortNo, Family) ->
     gen_server:call(erl_epmd, {register, Name, PortNo, Family}, infinity).
 
 -spec address_please(Name, Host, AddressFamily) -> Success | {error, term()} when
-	  Name :: string(),
-	  Host :: string() | inet:ip_address(),
-	  AddressFamily :: inet | inet6,
-	  Port :: non_neg_integer(),
-	  Version :: non_neg_integer(),
-	  Success :: {ok, inet:ip_address()} |
+    Name :: string(),
+    Host :: string() | inet:ip_address(),
+    AddressFamily :: inet | inet6,
+    Port :: non_neg_integer(),
+    Version :: non_neg_integer(),
+    Success :: {ok, inet:ip_address()} |
                      %% This is not returned here, but is in the spec for
                      %% the documentation to show that it is possible to
                      %% return when using a custom erl_epmd
@@ -215,7 +214,7 @@ address_please(_Name, Host, AddressFamily) ->
 
 init(_) ->
     {ok, #state{socket = -1}}.
-	    
+
 %%----------------------------------------------------------------------
 
 -type calls() :: 'client_info_req' | 'stop' | {'register', term(), term()}.
@@ -225,14 +224,14 @@ init(_) ->
 
 handle_call({register, Name, PortNo, Family}, _From, State) ->
     case State#state.socket of
-	P when P < 0 ->
-	    case do_register_node(Name, PortNo, Family) of
-		{alive, Socket, Creation} ->
-		    S = State#state{socket = Socket,
-				    port_no = PortNo,
-				    name = Name,
-				    family = Family},
-		    {reply, {ok, Creation}, S};
+  P when P < 0 ->
+      case do_register_node(Name, PortNo, Family) of
+    {alive, Socket, Creation} ->
+        S = State#state{socket = Socket,
+            port_no = PortNo,
+            name = Name,
+            family = Family},
+        {reply, {ok, Creation}, S};
                 Error ->
                     case init:get_argument(erl_epmd_port) of
                         {ok, _} ->
@@ -242,15 +241,15 @@ handle_call({register, Name, PortNo, Family}, _From, State) ->
                         error ->
                             {reply, Error, State}
                     end
-	    end;
-	_ ->
-	    {reply, {error, already_registered}, State}
+      end;
+  _ ->
+      {reply, {error, already_registered}, State}
     end;
 
 handle_call(client_info_req, _From, State) ->
     Reply = {ok,{r4,State#state.name,State#state.port_no}},
     {reply, Reply, State};
-  
+
 handle_call(stop, _From, State) ->
     {stop, shutdown, ok, State}.
 
@@ -270,12 +269,12 @@ handle_info({tcp_closed, Socket}, State) when State#state.socket =:= Socket ->
     {noreply, State#state{socket = -1}};
 handle_info(reconnect, State) when State#state.socket =:= -1 ->
     case do_register_node(State#state.name, State#state.port_no, State#state.family) of
-	{alive, Socket, _Creation} ->
+  {alive, Socket, _Creation} ->
             %% ignore the received creation
             {noreply, State#state{socket = Socket}};
-	_Error ->
-	    erlang:send_after(?RECONNECT_TIME, self(), reconnect),
-	    {noreply, State}
+  _Error ->
+      erlang:send_after(?RECONNECT_TIME, self(), reconnect),
+      {noreply, State}
     end;
 handle_info(_, State) ->
     {noreply, State}.
@@ -303,12 +302,12 @@ code_change(_OldVsn, State, _Extra) ->
 
 get_epmd_port() ->
     case init:get_argument(epmd_port) of
-	{ok, [[PortStr|_]|_]} when is_list(PortStr) ->
-	    list_to_integer(PortStr);
-	error ->
-	    ?erlang_daemon_port
+  {ok, [[PortStr|_]|_]} when is_list(PortStr) ->
+      list_to_integer(PortStr);
+  error ->
+      ?erlang_daemon_port
     end.
-	    
+
 %%
 %% Epmd socket
 %%
@@ -333,11 +332,11 @@ do_register_node(NodeName, TcpPort, Family) ->
         inet6 -> open({0,0,0,0,0,0,0,1})
     end,
     case Localhost of
-	{ok, Socket} ->
-	    Name = to_string(NodeName),
-	    Extra = "",
-	    Elen = length(Extra),
-	    Len = 1+2+1+1+2+2+2+length(Name)+2+Elen,
+  {ok, Socket} ->
+      Name = to_string(NodeName),
+      Extra = "",
+      Elen = length(Extra),
+      Len = 1+2+1+1+2+2+2+length(Name)+2+Elen,
             Packet = [?int16(Len), ?EPMD_ALIVE2_REQ,
                       ?int16(TcpPort),
                       $M,
@@ -348,156 +347,156 @@ do_register_node(NodeName, TcpPort, Family) ->
                       Name,
                       ?int16(Elen),
                       Extra],
-	    case gen_tcp:send(Socket, Packet) of
+      case gen_tcp:send(Socket, Packet) of
                 ok ->
                     wait_for_reg_reply(Socket, []);
                 Error ->
                     close(Socket),
                     Error
             end;
-	Error ->
+  Error ->
             Error
     end.
 
 epmd_dist_high() ->
     case os:getenv("ERL_EPMD_DIST_HIGH") of
-	false ->
-	   ?epmd_dist_high; 
-	Version ->
-	    case (catch list_to_integer(Version)) of
-		N when is_integer(N), N < ?epmd_dist_high ->
-		    N;
-		_ ->
-		   ?epmd_dist_high
-	    end
+  false ->
+     ?epmd_dist_high;
+  Version ->
+      case (catch list_to_integer(Version)) of
+    N when is_integer(N), N < ?epmd_dist_high ->
+        N;
+    _ ->
+       ?epmd_dist_high
+      end
     end.
 
 epmd_dist_low() ->
     case os:getenv("ERL_EPMD_DIST_LOW") of
-	false ->
-	   ?epmd_dist_low; 
-	Version ->
-	    case (catch list_to_integer(Version)) of
-		N when is_integer(N), N > ?epmd_dist_low ->
-		    N;
-		_ ->
-		   ?epmd_dist_low
-	    end
+  false ->
+     ?epmd_dist_low;
+  Version ->
+      case (catch list_to_integer(Version)) of
+    N when is_integer(N), N > ?epmd_dist_low ->
+        N;
+    _ ->
+       ?epmd_dist_low
+      end
     end.
-		    
+
 
 
 %%% (When we reply 'duplicate_name', it's because it's the most likely
 %%% reason; there is no interpretation of the error result code.)
 wait_for_reg_reply(Socket, SoFar) ->
     receive
-	{tcp, Socket, Data0} ->
-	    case SoFar ++ Data0 of
-		[$v, Result, A, B, C, D] ->
-		    case Result of
-			0 ->
-			    {alive, Socket, ?u32(A, B, C, D)};
-			_ ->
-			    {error, duplicate_name}
-		    end;
-		[$y, Result, A, B] ->
-		    case Result of
-			0 ->
-			    {alive, Socket, ?u16(A, B)};
-			_ ->
-			    {error, duplicate_name}
-		    end;
-		Data when length(Data) < 4 ->
-		    wait_for_reg_reply(Socket, Data);
-		Garbage ->
-		    {error, {garbage_from_epmd, Garbage}}
-	    end;
-	{tcp_closed, Socket} ->
-	    {error, epmd_close}
+  {tcp, Socket, Data0} ->
+      case SoFar ++ Data0 of
+    [$v, Result, A, B, C, D] ->
+        case Result of
+      0 ->
+          {alive, Socket, ?u32(A, B, C, D)};
+      _ ->
+          {error, duplicate_name}
+        end;
+    [$y, Result, A, B] ->
+        case Result of
+      0 ->
+          {alive, Socket, ?u16(A, B)};
+      _ ->
+          {error, duplicate_name}
+        end;
+    Data when length(Data) < 4 ->
+        wait_for_reg_reply(Socket, Data);
+    Garbage ->
+        {error, {garbage_from_epmd, Garbage}}
+      end;
+  {tcp_closed, Socket} ->
+      {error, epmd_close}
     after 10000 ->
-	    gen_tcp:close(Socket),
-	    {error, no_reg_reply_from_epmd}
+      gen_tcp:close(Socket),
+      {error, no_reg_reply_from_epmd}
     end.
-    
+
 %%
 %% Lookup a node "Name" at Host
 %%
 
 get_port(Node, EpmdAddress, Timeout) ->
     case open(EpmdAddress, Timeout) of
-	{ok, Socket} ->
-	    Name = to_string(Node),
-	    Len = 1+length(Name),
-	    Msg = [?int16(Len),?EPMD_PORT_PLEASE2_REQ,Name],
-	    case gen_tcp:send(Socket, Msg) of
-		ok ->
-		    wait_for_port_reply(Socket, []);
-		_Error ->
-		    ?port_please_failure2(_Error),
-		    noport
-	    end;
-	_Error ->
+  {ok, Socket} ->
+      Name = to_string(Node),
+      Len = 1+length(Name),
+      Msg = [?int16(Len),?EPMD_PORT_PLEASE2_REQ,Name],
+      case gen_tcp:send(Socket, Msg) of
+    ok ->
+        wait_for_port_reply(Socket, []);
+    _Error ->
+        ?port_please_failure2(_Error),
+        noport
+      end;
+  _Error ->
             noport
     end.
 
 
 wait_for_port_reply(Socket, SoFar) ->
     receive
-	{tcp, Socket, Data0} ->
-%	    io:format("got ~p~n", [Data0]),
-	    case SoFar ++ Data0 of
-		[$w, Result | Rest] ->
-		    case Result of
-			0 ->
-			    wait_for_port_reply_cont(Socket, Rest);
-			_ ->
-			    ?port_please_failure(),
-			    wait_for_close(Socket, noport)
-		    end;
-		Data when length(Data) < 2 ->
-		    wait_for_port_reply(Socket, Data);
-		Garbage ->
-		    ?port_please_failure(),
-		    {error, {garbage_from_epmd, Garbage}}
-	    end;
-	{tcp_closed, Socket} ->
-	    ?port_please_failure(),
-	    closed
+  {tcp, Socket, Data0} ->
+%     io:format("got ~p~n", [Data0]),
+      case SoFar ++ Data0 of
+    [$w, Result | Rest] ->
+        case Result of
+      0 ->
+          wait_for_port_reply_cont(Socket, Rest);
+      _ ->
+          ?port_please_failure(),
+          wait_for_close(Socket, noport)
+        end;
+    Data when length(Data) < 2 ->
+        wait_for_port_reply(Socket, Data);
+    Garbage ->
+        ?port_please_failure(),
+        {error, {garbage_from_epmd, Garbage}}
+      end;
+  {tcp_closed, Socket} ->
+      ?port_please_failure(),
+      closed
     after 10000 ->
-	    ?port_please_failure(),
-	    gen_tcp:close(Socket),
-	    noport
+      ?port_please_failure(),
+      gen_tcp:close(Socket),
+      noport
     end.
 
 wait_for_port_reply_cont(Socket, SoFar) when length(SoFar) >= 10 ->
     wait_for_port_reply_cont2(Socket, SoFar);
 wait_for_port_reply_cont(Socket, SoFar) ->
     receive
-	{tcp, Socket, Data0} ->
-	    case SoFar ++ Data0 of
-		Data when length(Data) >= 10 ->
-		    wait_for_port_reply_cont2(Socket, Data);
-		Data when length(Data) < 10 ->
-		    wait_for_port_reply_cont(Socket, Data);
-		Garbage ->
-		    ?port_please_failure(),
-		    {error, {garbage_from_epmd, Garbage}}
-	    end;
-	{tcp_closed, Socket} ->
-	    ?port_please_failure(),
-	    noport
+  {tcp, Socket, Data0} ->
+      case SoFar ++ Data0 of
+    Data when length(Data) >= 10 ->
+        wait_for_port_reply_cont2(Socket, Data);
+    Data when length(Data) < 10 ->
+        wait_for_port_reply_cont(Socket, Data);
+    Garbage ->
+        ?port_please_failure(),
+        {error, {garbage_from_epmd, Garbage}}
+      end;
+  {tcp_closed, Socket} ->
+      ?port_please_failure(),
+      noport
     after 10000 ->
-	    ?port_please_failure(),
-	    gen_tcp:close(Socket),
-	    noport
+      ?port_please_failure(),
+      gen_tcp:close(Socket),
+      noport
     end.
 
 wait_for_port_reply_cont2(Socket, Data) ->
     [A, B, _Type, _Proto, HighA, HighB,
      LowA, LowB, NLenA, NLenB | Rest] = Data,
     wait_for_port_reply_name(Socket,
-			     ?u16(NLenA, NLenB),
-			     Rest),
+           ?u16(NLenA, NLenB),
+           Rest),
     Low = ?u16(LowA, LowB),
     High = ?u16(HighA, HighB),
     Version = best_version(Low, High),
@@ -509,13 +508,13 @@ wait_for_port_reply_cont2(Socket, Data) ->
 %%% currently.
 wait_for_port_reply_name(Socket, Len, Sofar) ->
     receive
-	{tcp, Socket, _Data} ->
-%	    io:format("data = ~p~n", _Data),
-	    wait_for_port_reply_name(Socket, Len, Sofar);
-	{tcp_closed, Socket} ->
-	    ok
+  {tcp, Socket, _Data} ->
+%     io:format("data = ~p~n", _Data),
+      wait_for_port_reply_name(Socket, Len, Sofar);
+  {tcp_closed, Socket} ->
+      ok
     end.
-		    
+
 
 best_version(Low, High) ->
     OurLow =  epmd_dist_low(),
@@ -533,11 +532,11 @@ select_best_version(_L1, H1, _L2, H2) ->
 
 wait_for_close(Socket, Reply) ->
     receive
-	{tcp_closed, Socket} -> 
-	    Reply
+  {tcp_closed, Socket} ->
+      Reply
     after 10000 ->
-	    gen_tcp:close(Socket),
-	    Reply
+      gen_tcp:close(Socket),
+      Reply
     end.
 
 
@@ -554,53 +553,53 @@ to_string(S) when is_list(S) -> S.
 %%
 get_names(EpmdAddress) ->
     case open(EpmdAddress) of
-	{ok, Socket} ->
-	    do_get_names(Socket);
-	_Error ->
-	    {error, address}
+  {ok, Socket} ->
+      do_get_names(Socket);
+  _Error ->
+      {error, address}
     end.
 
 do_get_names(Socket) ->
     case gen_tcp:send(Socket, [?int16(1),?EPMD_NAMES]) of
-	ok ->
-	    receive
-		{tcp, Socket, [P0,P1,P2,P3|T]} ->
-		    EpmdPort = ?u32(P0,P1,P2,P3),
-		    case get_epmd_port() of
-			EpmdPort ->
-			    names_loop(Socket, T, []);
-			_ ->
-			    close(Socket),
-			    {error, address}
-		    end;
-		{tcp_closed, Socket} ->
-		    {ok, []}
-	    end;
-	_ ->
-	    close(Socket),
-	    {error, address}
+  ok ->
+      receive
+    {tcp, Socket, [P0,P1,P2,P3|T]} ->
+        EpmdPort = ?u32(P0,P1,P2,P3),
+        case get_epmd_port() of
+      EpmdPort ->
+          names_loop(Socket, T, []);
+      _ ->
+          close(Socket),
+          {error, address}
+        end;
+    {tcp_closed, Socket} ->
+        {ok, []}
+      end;
+  _ ->
+      close(Socket),
+      {error, address}
     end.
 
 names_loop(Socket, Acc, Ps) ->
     receive
-	{tcp, Socket, Bytes} ->
-	    {NAcc, NPs} = scan_names(Acc ++ Bytes, Ps),
-	    names_loop(Socket, NAcc, NPs);
-	{tcp_closed, Socket} ->
-	    {_, NPs} = scan_names(Acc, Ps),
-	    {ok, NPs}
+  {tcp, Socket, Bytes} ->
+      {NAcc, NPs} = scan_names(Acc ++ Bytes, Ps),
+      names_loop(Socket, NAcc, NPs);
+  {tcp_closed, Socket} ->
+      {_, NPs} = scan_names(Acc, Ps),
+      {ok, NPs}
     end.
 
 scan_names(Buf, Ps) ->
     case scan_line(Buf, []) of
-	{Line, NBuf} ->
-	    case parse_line(Line) of
-		{ok, Entry} -> 
-		    scan_names(NBuf, [Entry | Ps]);
-		error ->
-		    scan_names(NBuf, Ps)
-	    end;
-	[] -> {Buf, Ps}
+  {Line, NBuf} ->
+      case parse_line(Line) of
+    {ok, Entry} ->
+        scan_names(NBuf, [Entry | Ps]);
+    error ->
+        scan_names(NBuf, Ps)
+      end;
+  [] -> {Buf, Ps}
     end.
 
 
@@ -610,16 +609,16 @@ scan_line([], _) -> [].
 
 parse_line("name " ++ Buf0) ->
     case parse_name(Buf0, []) of
-	{Name, Buf1}  ->
-	    case Buf1 of
-		"at port " ++ Buf2 ->
-		    case catch list_to_integer(Buf2) of
-			{'EXIT', _} -> error;
-			Port -> {ok, {Name, Port}}
-		    end;
-		_ -> error
-	    end;
-	error -> error
+  {Name, Buf1}  ->
+      case Buf1 of
+    "at port " ++ Buf2 ->
+        case catch list_to_integer(Buf2) of
+      {'EXIT', _} -> error;
+      Port -> {ok, {Name, Port}}
+        end;
+    _ -> error
+      end;
+  error -> error
     end;
 parse_line(_) -> error.
 

--- a/lib/kernel/src/inet_tcp_dist.erl
+++ b/lib/kernel/src/inet_tcp_dist.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 1997-2018. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(inet_tcp_dist).
@@ -22,14 +22,14 @@
 %% Handles the connection setup phase with other Erlang nodes.
 
 -export([listen/1, listen/2, accept/1, accept_connection/5,
-	 setup/5, close/1, select/1, address/0, is_node_name/1]).
+   setup/5, close/1, select/1, address/0, is_node_name/1]).
 
 %% Optional
 -export([setopts/2, getopts/2]).
 
 %% Generalized dist API
 -export([gen_listen/3, gen_accept/2, gen_accept_connection/6,
-	 gen_setup/6, gen_select/2, gen_address/1]).
+   gen_setup/6, gen_select/2, gen_address/1]).
 
 %% internal exports
 
@@ -55,12 +55,12 @@ select(Node) ->
 
 gen_select(Driver, Node) ->
     case split_node(atom_to_list(Node), $@, []) of
-	[_, Host] ->
-	    case inet:getaddr(Host, Driver:family()) of
+  [_, Host] ->
+      case inet:getaddr(Host, Driver:family()) of
                 {ok,_} -> true;
                 _ -> false
             end;
-	_ -> false
+  _ -> false
     end.
 
 %% ------------------------------------------------------------
@@ -86,18 +86,23 @@ listen(Name) ->
 
 gen_listen(Driver, Name, Host) ->
     ErlEpmd = net_kernel:epmd_module(),
-    case gen_listen(ErlEpmd, Name, Host, Driver, [{active, false}, {packet,2}, {reuseaddr, true}]) of
-	{ok, Socket} ->
-	    TcpAddress = get_tcp_address(Driver, Socket),
-	    {_,Port} = TcpAddress#net_address.address,
-	    case ErlEpmd:register_node(Name, Port, Driver) of
-		{ok, Creation} ->
-		    {ok, {Socket, TcpAddress, Creation}};
-		Error ->
-		    Error
-	    end;
-	Error ->
-	    Error
+    OnlyIPV6 = case Driver:family() of
+                   inet -> [];
+                   inet6 -> [{ipv6_v6only, true}]
+               end,
+    case gen_listen(ErlEpmd, Name, Host, Driver,
+                    [{active, false}, {packet,2}, {reuseaddr, true} | OnlyIPV6]) of
+  {ok, Socket} ->
+      TcpAddress = get_tcp_address(Driver, Socket),
+      {_,Port} = TcpAddress#net_address.address,
+      case ErlEpmd:register_node(Name, Port, Driver) of
+    {ok, Creation} ->
+        {ok, {Socket, TcpAddress, Creation}};
+    Error ->
+        Error
+      end;
+  Error ->
+      Error
     end.
 
 gen_listen(ErlEpmd, Name, Host, Driver, Options) ->
@@ -127,30 +132,30 @@ do_listen(_Driver, First,Last,_) when First > Last ->
     {error,eaddrinuse};
 do_listen(Driver, First,Last,Options) ->
     case Driver:listen(First, Options) of
-	{error, eaddrinuse} ->
-	    do_listen(Driver, First+1,Last,Options);
-	Other ->
-	    Other
+  {error, eaddrinuse} ->
+      do_listen(Driver, First+1,Last,Options);
+  Other ->
+      Other
     end.
 
 listen_options(Opts0) ->
     Opts1 =
-	case application:get_env(kernel, inet_dist_use_interface) of
-	    {ok, Ip} ->
-		[{ip, Ip} | Opts0];
-	    _ ->
-		Opts0
-	end,
+  case application:get_env(kernel, inet_dist_use_interface) of
+      {ok, Ip} ->
+    [{ip, Ip} | Opts0];
+      _ ->
+    Opts0
+  end,
     case application:get_env(kernel, inet_dist_listen_options) of
-	{ok,ListenOpts} ->
-	    case proplists:is_defined(backlog, ListenOpts) of
-		true ->
-		    ListenOpts ++ Opts1;
-		false ->
-		    ListenOpts ++ [{backlog, 128} | Opts1]
-	    end;
-	_ ->
-	    [{backlog, 128} | Opts1]
+  {ok,ListenOpts} ->
+      case proplists:is_defined(backlog, ListenOpts) of
+    true ->
+        ListenOpts ++ Opts1;
+    false ->
+        ListenOpts ++ [{backlog, 128} | Opts1]
+      end;
+  _ ->
+      [{backlog, 128} | Opts1]
     end.
 
 
@@ -166,35 +171,35 @@ gen_accept(Driver, Listen) ->
 
 accept_loop(Driver, Kernel, Listen) ->
     case Driver:accept(Listen) of
-	{ok, Socket} ->
-	    Kernel ! {accept,self(),Socket,Driver:family(),tcp},
-	    _ = controller(Driver, Kernel, Socket),
-	    accept_loop(Driver, Kernel, Listen);
-	Error ->
-	    exit(Error)
+  {ok, Socket} ->
+      Kernel ! {accept,self(),Socket,Driver:family(),tcp},
+      _ = controller(Driver, Kernel, Socket),
+      accept_loop(Driver, Kernel, Listen);
+  Error ->
+      exit(Error)
     end.
 
 controller(Driver, Kernel, Socket) ->
     receive
-	{Kernel, controller, Pid} ->
-	    flush_controller(Pid, Socket),
-	    Driver:controlling_process(Socket, Pid),
-	    flush_controller(Pid, Socket),
-	    Pid ! {self(), controller};
-	{Kernel, unsupported_protocol} ->
-	    exit(unsupported_protocol)
+  {Kernel, controller, Pid} ->
+      flush_controller(Pid, Socket),
+      Driver:controlling_process(Socket, Pid),
+      flush_controller(Pid, Socket),
+      Pid ! {self(), controller};
+  {Kernel, unsupported_protocol} ->
+      exit(unsupported_protocol)
     end.
 
 flush_controller(Pid, Socket) ->
     receive
-	{tcp, Socket, Data} ->
-	    Pid ! {tcp, Socket, Data},
-	    flush_controller(Pid, Socket);
-	{tcp_closed, Socket} ->
-	    Pid ! {tcp_closed, Socket},
-	    flush_controller(Pid, Socket)
+  {tcp, Socket, Data} ->
+      Pid ! {tcp, Socket, Data},
+      flush_controller(Pid, Socket);
+  {tcp_closed, Socket} ->
+      Pid ! {tcp_closed, Socket},
+      flush_controller(Pid, Socket)
     after 0 ->
-	    ok
+      ok
     end.
 
 %% ------------------------------------------------------------
@@ -207,55 +212,55 @@ accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
 
 gen_accept_connection(Driver, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     spawn_opt(?MODULE, do_accept,
-	      [Driver, self(), AcceptPid, Socket, MyNode, Allowed, SetupTime],
-	      [link, {priority, max}]).
+        [Driver, self(), AcceptPid, Socket, MyNode, Allowed, SetupTime],
+        [link, {priority, max}]).
 
 do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     receive
-	{AcceptPid, controller} ->
-	    Timer = dist_util:start_timer(SetupTime),
-	    case check_ip(Driver, Socket) of
-		true ->
-		    HSData = #hs_data{
-		      kernel_pid = Kernel,
-		      this_node = MyNode,
-		      socket = Socket,
-		      timer = Timer,
-		      this_flags = 0,
-		      allowed = Allowed,
-		      f_send = fun Driver:send/2,
-		      f_recv = fun Driver:recv/3,
-		      f_setopts_pre_nodeup = 
-		      fun(S) ->
-			      inet:setopts(S, 
-					   [{active, false},
-					    {packet, 4},
-					    nodelay()])
-		      end,
-		      f_setopts_post_nodeup = 
-		      fun(S) ->
-			      inet:setopts(S, 
-					   [{active, true},
-					    {deliver, port},
-					    {packet, 4},
+  {AcceptPid, controller} ->
+      Timer = dist_util:start_timer(SetupTime),
+      case check_ip(Driver, Socket) of
+    true ->
+        HSData = #hs_data{
+          kernel_pid = Kernel,
+          this_node = MyNode,
+          socket = Socket,
+          timer = Timer,
+          this_flags = 0,
+          allowed = Allowed,
+          f_send = fun Driver:send/2,
+          f_recv = fun Driver:recv/3,
+          f_setopts_pre_nodeup =
+          fun(S) ->
+            inet:setopts(S,
+             [{active, false},
+              {packet, 4},
+              nodelay()])
+          end,
+          f_setopts_post_nodeup =
+          fun(S) ->
+            inet:setopts(S,
+             [{active, true},
+              {deliver, port},
+              {packet, 4},
                                             binary,
-					    nodelay()])
-		      end,
-		      f_getll = fun(S) ->
-					inet:getll(S)
-				end,
-		      f_address = fun(S, Node) -> get_remote_id(Driver, S, Node) end,
-		      mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
-		      mf_getstat = fun ?MODULE:getstat/1,
-		      mf_setopts = fun ?MODULE:setopts/2,
-		      mf_getopts = fun ?MODULE:getopts/2
-		     },
-		    dist_util:handshake_other_started(HSData);
-		{false,IP} ->
-		    error_msg("** Connection attempt from "
-			      "disallowed IP ~w ** ~n", [IP]),
-		    ?shutdown(no_node)
-	    end
+              nodelay()])
+          end,
+          f_getll = fun(S) ->
+          inet:getll(S)
+        end,
+          f_address = fun(S, Node) -> get_remote_id(Driver, S, Node) end,
+          mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
+          mf_getstat = fun ?MODULE:getstat/1,
+          mf_setopts = fun ?MODULE:setopts/2,
+          mf_getopts = fun ?MODULE:getopts/2
+         },
+        dist_util:handshake_other_started(HSData);
+    {false,IP} ->
+        error_msg("** Connection attempt from "
+            "disallowed IP ~w ** ~n", [IP]),
+        ?shutdown(no_node)
+      end
     end.
 
 
@@ -264,14 +269,14 @@ do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
 
 nodelay() ->
     case application:get_env(kernel, dist_nodelay) of
-	undefined ->
-	    {nodelay, true};
-	{ok, true} ->
-	    {nodelay, true};
-	{ok, false} ->
-	    {nodelay, false};
-	_ ->
-	    {nodelay, true}
+  undefined ->
+      {nodelay, true};
+  {ok, true} ->
+      {nodelay, true};
+  {ok, false} ->
+      {nodelay, false};
+  _ ->
+      {nodelay, true}
     end.
 
 
@@ -280,17 +285,17 @@ nodelay() ->
 %% ------------------------------------------------------------
 get_remote_id(Driver, Socket, Node) ->
     case inet:peername(Socket) of
-	{ok,Address} ->
-	    case split_node(atom_to_list(Node), $@, []) of
-		[_,Host] ->
-		    #net_address{address=Address,host=Host,
-				 protocol=tcp,family=Driver:family()};
-		_ ->
-		    %% No '@' or more than one '@' in node name.
-		    ?shutdown(no_node)
-	    end;
-	{error, _Reason} ->
-	    ?shutdown(no_node)
+  {ok,Address} ->
+      case split_node(atom_to_list(Node), $@, []) of
+    [_,Host] ->
+        #net_address{address=Address,host=Host,
+         protocol=tcp,family=Driver:family()};
+    _ ->
+        %% No '@' or more than one '@' in node name.
+        ?shutdown(no_node)
+      end;
+  {error, _Reason} ->
+      ?shutdown(no_node)
     end.
 
 %% ------------------------------------------------------------
@@ -302,9 +307,9 @@ setup(Node, Type, MyNode, LongOrShortNames,SetupTime) ->
     gen_setup(inet_tcp, Node, Type, MyNode, LongOrShortNames, SetupTime).
 
 gen_setup(Driver, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
-    spawn_opt(?MODULE, do_setup, 
-	      [Driver, self(), Node, Type, MyNode, LongOrShortNames, SetupTime],
-	      [link, {priority, max}]).
+    spawn_opt(?MODULE, do_setup,
+        [Driver, self(), Node, Type, MyNode, LongOrShortNames, SetupTime],
+        [link, {priority, max}]).
 
 do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
     ?trace("~p~n",[{inet_tcp_dist,self(),setup,Node}]),
@@ -313,26 +318,26 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
     ErlEpmd = net_kernel:epmd_module(),
     Timer = dist_util:start_timer(SetupTime),
     case call_epmd_function(ErlEpmd,address_please,[Name, Address, AddressFamily]) of
-	{ok, Ip, TcpPort, Version} ->
-		?trace("address_please(~p) -> version ~p~n",
-			[Node,Version]),
-		do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
-		                 Ip, TcpPort, Version, Type, MyNode, Timer);
-	{ok, Ip} ->
-	    case ErlEpmd:port_please(Name, Ip) of
-		{port, TcpPort, Version} ->
-		    ?trace("port_please(~p) -> version ~p~n", 
-			   [Node,Version]),
-			do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
-			                 Ip, TcpPort, Version, Type, MyNode, Timer);
-		_ ->
-		    ?trace("port_please (~p) failed.~n", [Node]),
-		    ?shutdown(Node)
-	    end;
-	_Other ->
-	    ?trace("inet_getaddr(~p) "
-		   "failed (~p).~n", [Node,_Other]),
-	    ?shutdown(Node)
+  {ok, Ip, TcpPort, Version} ->
+    ?trace("address_please(~p) -> version ~p~n",
+      [Node,Version]),
+    do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
+                     Ip, TcpPort, Version, Type, MyNode, Timer);
+  {ok, Ip} ->
+      case ErlEpmd:port_please(Name, Ip) of
+    {port, TcpPort, Version} ->
+        ?trace("port_please(~p) -> version ~p~n",
+         [Node,Version]),
+      do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
+                       Ip, TcpPort, Version, Type, MyNode, Timer);
+    _ ->
+        ?trace("port_please (~p) failed.~n", [Node]),
+        ?shutdown(Node)
+      end;
+  _Other ->
+      ?trace("inet_getaddr(~p) "
+       "failed (~p).~n", [Node,_Other]),
+      ?shutdown(Node)
     end.
 
 %%
@@ -340,72 +345,72 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 %%
 do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
                  Ip, TcpPort, Version, Type, MyNode, Timer) ->
-	dist_util:reset_timer(Timer),
-	case
-	Driver:connect(
-	  Ip, TcpPort,
-	  connect_options([{active, false}, {packet, 2}]))
-	of
-	{ok, Socket} ->
-		HSData = #hs_data{
-		  kernel_pid = Kernel,
-		  other_node = Node,
-		  this_node = MyNode,
-		  socket = Socket,
-		  timer = Timer,
-		  this_flags = 0,
-		  other_version = Version,
-		  f_send = fun Driver:send/2,
-		  f_recv = fun Driver:recv/3,
-		  f_setopts_pre_nodeup =
-		  fun(S) ->
-			  inet:setopts
-			(S,
-			 [{active, false},
-			  {packet, 4},
-			  nodelay()])
-		  end,
-		  f_setopts_post_nodeup =
-		  fun(S) ->
-			  inet:setopts
-			(S,
-			 [{active, true},
-			  {deliver, port},
-			  {packet, 4},
-			  nodelay()])
-		  end,
+  dist_util:reset_timer(Timer),
+  case
+  Driver:connect(
+    Ip, TcpPort,
+    connect_options([{active, false}, {packet, 2}]))
+  of
+  {ok, Socket} ->
+    HSData = #hs_data{
+      kernel_pid = Kernel,
+      other_node = Node,
+      this_node = MyNode,
+      socket = Socket,
+      timer = Timer,
+      this_flags = 0,
+      other_version = Version,
+      f_send = fun Driver:send/2,
+      f_recv = fun Driver:recv/3,
+      f_setopts_pre_nodeup =
+      fun(S) ->
+        inet:setopts
+      (S,
+       [{active, false},
+        {packet, 4},
+        nodelay()])
+      end,
+      f_setopts_post_nodeup =
+      fun(S) ->
+        inet:setopts
+      (S,
+       [{active, true},
+        {deliver, port},
+        {packet, 4},
+        nodelay()])
+      end,
 
-		  f_getll = fun inet:getll/1,
-		  f_address =
-		  fun(_,_) ->
-			  #net_address{
-		   address = {Ip,TcpPort},
-		   host = Address,
-		   protocol = tcp,
-		   family = AddressFamily}
-		  end,
-		  mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
-		  mf_getstat = fun ?MODULE:getstat/1,
-		  request_type = Type,
-		  mf_setopts = fun ?MODULE:setopts/2,
-		  mf_getopts = fun ?MODULE:getopts/2
-		 },
-		dist_util:handshake_we_started(HSData);
-	_ ->
-		%% Other Node may have closed since
-		%% discovery !
-		?trace("other node (~p) "
-		   "closed since discovery (port_please).~n",
-		   [Node]),
-		?shutdown(Node)
-	end.
+      f_getll = fun inet:getll/1,
+      f_address =
+      fun(_,_) ->
+        #net_address{
+       address = {Ip,TcpPort},
+       host = Address,
+       protocol = tcp,
+       family = AddressFamily}
+      end,
+      mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
+      mf_getstat = fun ?MODULE:getstat/1,
+      request_type = Type,
+      mf_setopts = fun ?MODULE:setopts/2,
+      mf_getopts = fun ?MODULE:getopts/2
+     },
+    dist_util:handshake_we_started(HSData);
+  _ ->
+    %% Other Node may have closed since
+    %% discovery !
+    ?trace("other node (~p) "
+       "closed since discovery (port_please).~n",
+       [Node]),
+    ?shutdown(Node)
+  end.
 
 connect_options(Opts) ->
     case application:get_env(kernel, inet_dist_connect_options) of
-	{ok,ConnectOpts} ->
-	    ConnectOpts ++ Opts;
-	_ ->
-	    Opts
+  {ok,ConnectOpts} ->
+      ConnectOpts ++ Opts;
+  _ ->
+      Opts
     end.
 
 %%
@@ -418,10 +423,10 @@ close(Socket) ->
 %% If Node is illegal terminate the connection setup!!
 splitnode(Driver, Node, LongOrShortNames) ->
     case split_node(atom_to_list(Node), $@, []) of
-	[Name|Tail] when Tail =/= [] ->
-	    Host = lists:append(Tail),
-	    case split_node(Host, $., []) of
-		[_] when LongOrShortNames =:= longnames ->
+  [Name|Tail] when Tail =/= [] ->
+      Host = lists:append(Tail),
+      case split_node(Host, $., []) of
+    [_] when LongOrShortNames =:= longnames ->
                     case Driver:parse_address(Host) of
                         {ok, _} ->
                             [Name, Host];
@@ -433,22 +438,22 @@ splitnode(Driver, Node, LongOrShortNames) ->
                                       [Host]),
                             ?shutdown(Node)
                     end;
-		L when length(L) > 1, LongOrShortNames =:= shortnames ->
-		    error_msg("** System NOT running to use fully qualified "
-			      "hostnames **~n"
-			      "** Hostname ~ts is illegal **~n",
-			      [Host]),
-		    ?shutdown(Node);
-		_ ->
-		    [Name, Host]
-	    end;
-	[_] ->
-	    error_msg("** Nodename ~p illegal, no '@' character **~n",
-		      [Node]),
-	    ?shutdown(Node);
-	_ ->
-	    error_msg("** Nodename ~p illegal **~n", [Node]),
-	    ?shutdown(Node)
+    L when length(L) > 1, LongOrShortNames =:= shortnames ->
+        error_msg("** System NOT running to use fully qualified "
+            "hostnames **~n"
+            "** Hostname ~ts is illegal **~n",
+            [Host]),
+        ?shutdown(Node);
+    _ ->
+        [Name, Host]
+      end;
+  [_] ->
+      error_msg("** Nodename ~p illegal, no '@' character **~n",
+          [Node]),
+      ?shutdown(Node);
+  _ ->
+      error_msg("** Nodename ~p illegal **~n", [Node]),
+      ?shutdown(Node)
     end.
 
 split_node([Chr|T], Chr, Ack) -> [lists:reverse(Ack)|split_node(T, Chr, [])];
@@ -465,10 +470,10 @@ get_tcp_address(Driver, Socket) ->
 get_tcp_address(Driver) ->
     {ok, Host} = inet:gethostname(),
     #net_address {
-		  host = Host,
-		  protocol = tcp,
-		  family = Driver:family()
-		 }.
+      host = Host,
+      protocol = tcp,
+      family = Driver:family()
+     }.
 
 %% ------------------------------------------------------------
 %% Determine if EPMD module supports the called functions.
@@ -486,59 +491,59 @@ call_epmd_function(Mod, Fun, Args) ->
 %% ------------------------------------------------------------
 check_ip(Driver, Socket) ->
     case application:get_env(check_ip) of
-	{ok, true} ->
-	    case get_ifs(Socket) of
-		{ok, IFs, IP} ->
-		    check_ip(Driver, IFs, IP);
-		_ ->
-		    ?shutdown(no_node)
-	    end;
-	_ ->
-	    true
+  {ok, true} ->
+      case get_ifs(Socket) of
+    {ok, IFs, IP} ->
+        check_ip(Driver, IFs, IP);
+    _ ->
+        ?shutdown(no_node)
+      end;
+  _ ->
+      true
     end.
 
 get_ifs(Socket) ->
     case inet:peername(Socket) of
-	{ok, {IP, _}} ->
-	    case inet:getif(Socket) of
-		{ok, IFs} -> {ok, IFs, IP};
-		Error     -> Error
-	    end;
-	Error ->
-	    Error
+  {ok, {IP, _}} ->
+      case inet:getif(Socket) of
+    {ok, IFs} -> {ok, IFs, IP};
+    Error     -> Error
+      end;
+  Error ->
+      Error
     end.
 
 check_ip(Driver, [{OwnIP, _, Netmask}|IFs], PeerIP) ->
     case {Driver:mask(Netmask, PeerIP), Driver:mask(Netmask, OwnIP)} of
-	{M, M} -> true;
-	_      -> check_ip(Driver, IFs, PeerIP)
+  {M, M} -> true;
+  _      -> check_ip(Driver, IFs, PeerIP)
     end;
 check_ip(_Driver, [], PeerIP) ->
     {false, PeerIP}.
-    
+
 is_node_name(Node) when is_atom(Node) ->
     case split_node(atom_to_list(Node), $@, []) of
-	[_, _Host] -> true;
-	_ -> false
+  [_, _Host] -> true;
+  _ -> false
     end;
 is_node_name(_Node) ->
     false.
 
 tick(Driver, Socket) ->
     case Driver:send(Socket, [], [force]) of
-	{error, closed} ->
-	    self() ! {tcp_closed, Socket},
-	    {error, closed};
-	R ->
-	    R
+  {error, closed} ->
+      self() ! {tcp_closed, Socket},
+      {error, closed};
+  R ->
+      R
     end.
 
 getstat(Socket) ->
     case inet:getstat(Socket, [recv_cnt, send_cnt, send_pend]) of
-	{ok, Stat} ->
-	    split_stat(Stat,0,0,0);
-	Error ->
-	    Error
+  {ok, Stat} ->
+      split_stat(Stat,0,0,0);
+  Error ->
+      Error
     end.
 
 split_stat([{recv_cnt, R}|Stat], _, W, P) ->
@@ -553,9 +558,9 @@ split_stat([], R, W, P) ->
 
 setopts(S, Opts) ->
     case [Opt || {K,_}=Opt <- Opts,
-		 K =:= active orelse K =:= deliver orelse K =:= packet] of
-	[] -> inet:setopts(S,Opts);
-	Opts1 -> {error, {badopts,Opts1}}
+     K =:= active orelse K =:= deliver orelse K =:= packet] of
+  [] -> inet:setopts(S,Opts);
+  Opts1 -> {error, {badopts,Opts1}}
     end.
 
 getopts(S, Opts) ->

--- a/lib/os_mon/src/os_mon.erl
+++ b/lib/os_mon/src/os_mon.erl
@@ -113,7 +113,7 @@ stop(_) ->
 init([]) ->
     SupFlags = case os:type() of
 		   {win32, _} ->
-		       {one_for_one, 5, 3600};
+		       {one_for_one, 8, 5};
 		   _ ->
 		       {one_for_one, 4, 3600}
 	       end,

--- a/lib/os_mon/src/os_mon_sysinfo.erl
+++ b/lib/os_mon/src/os_mon_sysinfo.erl
@@ -125,5 +125,5 @@ get_data(Port, Sofar) ->
 	{'EXIT', Port, Reason} ->
 	    exit({port_died, Reason})
     after 5000 ->
-	    lists:reverse(Sofar)
+	    exit({port_error, timeout})
     end.

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1788,8 +1788,10 @@ verify_hostname_match_default0(FQDN=[_|_], {cn,FQDN}) ->
     not lists:member($*, FQDN);
 verify_hostname_match_default0(FQDN=[_|_], {cn,Name=[_|_]}) -> 
     verify_hostname_match_wildcard(FQDN, Name);
-verify_hostname_match_default0({dns_id,R}, {dNSName,P}) ->
-    R==P;
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,FQDN}) ->
+    not lists:member($*, FQDN);
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,Name=[_|_]}) ->
+    verify_hostname_match_wildcard(FQDN, Name);
 verify_hostname_match_default0({uri_id,R}, {uniformResourceIdentifier,P}) ->
     R==P;
 verify_hostname_match_default0({ip,R}, {iPAddress,P}) when length(P) == 4 ->

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -535,10 +535,14 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 -spec do_setup_connect(_,_,_,_,_,_,_,_,_,_) -> no_return().
 
 do_setup_connect(Driver, Kernel, Node, Address, Ip, TcpPort, Version, Type, MyNode, Timer) ->
-    Opts =  trace(connect_options(get_ssl_options(client))),
+    Opts0 =  trace(connect_options(get_ssl_options(client))),
     dist_util:reset_timer(Timer),
+    Opts = case inet:parse_address(Address) of
+               {ok, _} -> Opts0;
+               _ -> [{server_name_indication, Address} | Opts0]
+           end,
     case ssl:connect(
-        Address, TcpPort,
+        Ip, TcpPort,
         [binary, {active, false}, {packet, 4},
             Driver:family(), {nodelay, true}] ++ Opts,
         net_kernel:connecttime()) of

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -259,9 +259,15 @@ accept_loop(Driver, Listen, Kernel, Socket) ->
                    Driver:family(), tls}),
             receive
                 {Kernel, controller, Pid} ->
-                    ok = ssl:controlling_process(SslSocket, Pid),
-                    trace(
-                      Pid ! {self(), controller});
+                    case ssl:controlling_process(SslSocket, Pid) of
+                        ok ->
+                            trace(Pid ! {self(), controller});
+                        Error ->
+                            trace(Pid ! {self(), exit}),
+                            ?LOG_ERROR(
+                              "Cannot control TLS distribution connection: ~p~n",
+                              [Error])
+                    end;
                 {Kernel, unsupported_protocol} ->
                     exit(trace(unsupported_protocol))
             end,
@@ -427,7 +433,11 @@ do_accept(
                   this_flags = 0,
                   allowed = NewAllowed},
             link(DistCtrl),
-            dist_util:handshake_other_started(trace(HSData))
+            dist_util:handshake_other_started(trace(HSData));
+        {AcceptPid, exit} ->
+            %% this can happen when connection was initiated, but dropped
+            %%  between TLS handshake completion and dist handshake start
+            ?shutdown2(MyNode, connection_setup_failed)
     end.
 
 allowed_nodes(_SslSocket, []) ->

--- a/lib/ssl/src/ssl_dist_sup.erl
+++ b/lib/ssl/src/ssl_dist_sup.erl
@@ -43,7 +43,7 @@ start_link() ->
     case init:get_argument(ssl_dist_optfile) of
         {ok, [File]} ->
             DistOpts = consult(File),
-            TabOpts = [set, protected, named_table],
+            TabOpts = [set, public, named_table],
             Tab = ets:new(ssl_dist_opts, TabOpts),
             true = ets:insert(Tab, DistOpts),
             supervisor:start_link({local, ?MODULE}, ?MODULE, []);

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 1999-2019. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,27 +14,26 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(io_SUITE).
 
 -export([all/0, suite/0]).
 
--export([error_1/1, float_g/1, otp_5403/1, otp_5813/1, otp_6230/1, 
+-export([error_1/1, float_g/1, otp_5403/1, otp_5813/1, otp_6230/1,
          otp_6282/1, otp_6354/1, otp_6495/1, otp_6517/1, otp_6502/1,
          manpage/1, otp_6708/1, otp_7084/0, otp_7084/1, otp_7421/1,
-	 io_lib_collect_line_3_wb/1, cr_whitespace_in_string/1,
-	 io_fread_newlines/1, otp_8989/1, io_lib_fread_literal/1,
-	 printable_range/1, bad_printable_range/1,
-	 io_lib_print_binary_depth_one/1, otp_10302/1, otp_10755/1,
+   io_lib_collect_line_3_wb/1, cr_whitespace_in_string/1,
+   io_fread_newlines/1, otp_8989/1, io_lib_fread_literal/1,
+   printable_range/1, bad_printable_range/1,
+   io_lib_print_binary_depth_one/1, otp_10302/1, otp_10755/1,
          otp_10836/1, io_lib_width_too_small/1,
          io_with_huge_message_queue/1, format_string/1,
-	 maps/1, coverage/1, otp_14178_unicode_atoms/1, otp_14175/1,
+   maps/1, coverage/1, otp_14178_unicode_atoms/1, otp_14175/1,
          otp_14285/1, limit_term/1, otp_14983/1, otp_15103/1, otp_15076/1,
          otp_15159/1, otp_15639/1, otp_15705/1, otp_15847/1, otp_15875/1,
          chars_limit/1, otp_17525/1]).
-
 -export([pretty/2, trf/3]).
 
 %%-define(debug, true).
@@ -55,7 +54,7 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,1}}].
 
-all() -> 
+all() ->
     [error_1, float_g, otp_5403, otp_5813, otp_6230,
      otp_6282, otp_6354, otp_6495, otp_6517, otp_6502,
      manpage, otp_6708, otp_7084, otp_7421,
@@ -136,16 +135,16 @@ float_g(Config) when is_list(Config) ->
      "5.0e+5"] = float_g_1("~.2g", 5.0, -2, 5),
 
     case catch fmt("~.1g", [0.5]) of
-	"0.5" ->
-	    ["5.0e-2",
-	     "0.5",
-	     "5.0e+0",
-	     "5.0e+1",
-	     "5.0e+2",
-	     "5.0e+3",
-	     "5.0e+4",
-	     "5.0e+5"] = float_g_1("~.1g", 5.0, -2, 5);
-	{'EXIT',_} -> ok
+  "0.5" ->
+      ["5.0e-2",
+       "0.5",
+       "5.0e+0",
+       "5.0e+1",
+       "5.0e+2",
+       "5.0e+3",
+       "5.0e+4",
+       "5.0e+5"] = float_g_1("~.1g", 5.0, -2, 5);
+  {'EXIT',_} -> ok
     end,
 
     ["4.99999e-2",
@@ -293,24 +292,24 @@ otp_6354(Config) when is_list(Config) ->
     "{1,{1,{2,3}}}" = p({1,{1,{2,3}}}, 1, 80, 100),
 
     bt(<<"{wwwww,{wwwww,{wwwww,{wwwww,{wwwww,lkjsldfj,klsdjfjklds,\n"
-	 "                                   sdkfjdsl,sdakfjdsklj,sdkljfsdj}}}}}">>,
+   "                                   sdkfjdsl,sdakfjdsklj,sdkljfsdj}}}}}">>,
        p({wwwww,{wwwww,{wwwww,{wwwww,{wwwww,lkjsldfj,klsdjfjklds,
-				      sdkfjdsl,sdakfjdsklj,sdkljfsdj}}}}}, -1)),
+              sdkfjdsl,sdakfjdsklj,sdkljfsdj}}}}}, -1)),
 
     bt(<<"{wwwww,\n"
-	 "    {wwwww,\n"
-	 "        {wwwww,\n"
-	 "            {wwwww,\n"
-	 "                {wwwww,\n"
-	 "                    {lkjsldfj,\n"
-	 "                        {klsdjfjklds,\n"
-	 "                            {klajsljls,\n"
-	 "                                #aaaaaaaaaaaaaaaaaaaaa"
-	 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa{}}}}}}}}}">>,
+   "    {wwwww,\n"
+   "        {wwwww,\n"
+   "            {wwwww,\n"
+   "                {wwwww,\n"
+   "                    {lkjsldfj,\n"
+   "                        {klsdjfjklds,\n"
+   "                            {klajsljls,\n"
+   "                                #aaaaaaaaaaaaaaaaaaaaa"
+   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa{}}}}}}}}}">>,
        p({wwwww,{wwwww,{wwwww,{wwwww,{wwwww,{lkjsldfj,
-					     {klsdjfjklds,{klajsljls,
-							   {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}}}}}}}}},
-	 -1)),
+               {klsdjfjklds,{klajsljls,
+                 {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}}}}}}}}},
+   -1)),
     "{{...},...}" = p({{a,b},{a,b,c},{d,e,f}},1,8,2),
     %% Closing brackets and parentheses count:
     "{{a,b,c},\n {{1,2,\n   3}}}" = p({{a,b,c},{{1,2,3}}},1,11,-1),
@@ -398,8 +397,8 @@ otp_6354(Config) when is_list(Config) ->
     "#c{f1 = d,f2 = e}" = p({c,d,e}, 4),
     %% -record(d, {a..., b..., c.., d...}).
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,bbbbbbbbbbbbbbbbbbbb = 2,\n"
-	 "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,\n"
-	 "   eeeeeeeeeeeeeeeeeeee = 5}">>,
+   "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,\n"
+   "   eeeeeeeeeeeeeeeeeeee = 5}">>,
        p({d,1,2,3,4,5}, -1)),
     "..." = p({d,1,2,3,4,5}, 0),
     "{...}" = p({d,1,2,3,4,5}, 1),
@@ -408,190 +407,190 @@ otp_6354(Config) when is_list(Config) ->
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,bbbbbbbbbbbbbbbbbbbb = 2,...}">>,
        p({d,1,2,3,4,5}, 4)),
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,bbbbbbbbbbbbbbbbbbbb = 2,\n"
-	 "   cccccccccccccccccccc = 3,...}">>,
+   "   cccccccccccccccccccc = 3,...}">>,
        p({d,1,2,3,4,5}, 5)), % longer than 80 characters...
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,bbbbbbbbbbbbbbbbbbbb = 2,\n"
-	 "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,...}">>,
+   "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,...}">>,
        p({d,1,2,3,4,5}, 6)),
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,bbbbbbbbbbbbbbbbbbbb = 2,\n"
-	 "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,\n"
-	 "   eeeeeeeeeeeeeeeeeeee = 5}">>,
+   "   cccccccccccccccccccc = 3,dddddddddddddddddddd = 4,\n"
+   "   eeeeeeeeeeeeeeeeeeee = 5}">>,
        p({d,1,2,3,4,5}, 7)),
     bt(<<"#rrrrr{\n"
-	 "    f1 = 1,\n"
-	 "    f2 = #rrrrr{f1 = a,f2 = b,f3 = c},\n"
-	 "    f3 =\n"
-	 "        #rrrrr{\n"
-	 "            f1 = h,f2 = i,\n"
-	 "            f3 =\n"
-	 "                #rrrrr{\n"
-	 "                    f1 = aa,\n"
-	 "                    f2 =\n"
-	 "                        #rrrrr{\n"
-	 "                            f1 = #rrrrr{f1 = a,f2 = b,f3 = c},\n"
-	 "                            f2 = 2,f3 = 3},\n"
-	 "                    f3 = bb}}}">>,
+   "    f1 = 1,\n"
+   "    f2 = #rrrrr{f1 = a,f2 = b,f3 = c},\n"
+   "    f3 =\n"
+   "        #rrrrr{\n"
+   "            f1 = h,f2 = i,\n"
+   "            f3 =\n"
+   "                #rrrrr{\n"
+   "                    f1 = aa,\n"
+   "                    f2 =\n"
+   "                        #rrrrr{\n"
+   "                            f1 = #rrrrr{f1 = a,f2 = b,f3 = c},\n"
+   "                            f2 = 2,f3 = 3},\n"
+   "                    f3 = bb}}}">>,
        p({rrrrr,1,{rrrrr,a,b,c},{rrrrr,h,i,
-				 {rrrrr,aa,{rrrrr,{rrrrr,a,b,c},
-					    2,3},bb}}},
-	 -1)),
+         {rrrrr,aa,{rrrrr,{rrrrr,a,b,c},
+              2,3},bb}}},
+   -1)),
     bt(<<"#d{aaaaaaaaaaaaaaaaaaaa = 1,\n"
-	 "   bbbbbbbbbbbbbbbbbbbb =\n"
-	 "       #d{aaaaaaaaaaaaaaaaaaaa = a,bbbbbbbbbbbbbbbbbbbb = b,\n"
-	 "          cccccccccccccccccccc = c,dddddddddddddddddddd = d,\n"
-	 "          eeeeeeeeeeeeeeeeeeee = e},\n"
-	 "   cccccccccccccccccccc = 3,\n"
-	 "   dddddddddddddddddddd =\n"
-	 "       #d{aaaaaaaaaaaaaaaaaaaa = h,bbbbbbbbbbbbbbbbbbbb = i,\n"
-	 "          cccccccccccccccccccc =\n"
-	 "              #d{aaaaaaaaaaaaaaaaaaaa = aa,"
-	 "bbbbbbbbbbbbbbbbbbbb = bb,\n"
-	 "                 cccccccccccccccccccc =\n"
-	 "                     #d{aaaaaaaaaaaaaaaaaaaa = 1,"
-	 "bbbbbbbbbbbbbbbbbbbb = 2,\n"
-	 "                        cccccccccccccccccccc = 3,"
-	 "dddddddddddddddddddd = 4,\n"
-	 "                        eeeeeeeeeeeeeeeeeeee = 5},\n"
-	 "                 dddddddddddddddddddd = dd,"
-	 "eeeeeeeeeeeeeeeeeeee = ee},\n"
-	 "          dddddddddddddddddddd = k,"
-	 "eeeeeeeeeeeeeeeeeeee = l},\n"
-	 "   eeeeeeeeeeeeeeeeeeee = 5}">>,
+   "   bbbbbbbbbbbbbbbbbbbb =\n"
+   "       #d{aaaaaaaaaaaaaaaaaaaa = a,bbbbbbbbbbbbbbbbbbbb = b,\n"
+   "          cccccccccccccccccccc = c,dddddddddddddddddddd = d,\n"
+   "          eeeeeeeeeeeeeeeeeeee = e},\n"
+   "   cccccccccccccccccccc = 3,\n"
+   "   dddddddddddddddddddd =\n"
+   "       #d{aaaaaaaaaaaaaaaaaaaa = h,bbbbbbbbbbbbbbbbbbbb = i,\n"
+   "          cccccccccccccccccccc =\n"
+   "              #d{aaaaaaaaaaaaaaaaaaaa = aa,"
+   "bbbbbbbbbbbbbbbbbbbb = bb,\n"
+   "                 cccccccccccccccccccc =\n"
+   "                     #d{aaaaaaaaaaaaaaaaaaaa = 1,"
+   "bbbbbbbbbbbbbbbbbbbb = 2,\n"
+   "                        cccccccccccccccccccc = 3,"
+   "dddddddddddddddddddd = 4,\n"
+   "                        eeeeeeeeeeeeeeeeeeee = 5},\n"
+   "                 dddddddddddddddddddd = dd,"
+   "eeeeeeeeeeeeeeeeeeee = ee},\n"
+   "          dddddddddddddddddddd = k,"
+   "eeeeeeeeeeeeeeeeeeee = l},\n"
+   "   eeeeeeeeeeeeeeeeeeee = 5}">>,
        p({d,1,{d,a,b,c,d,e},3,{d,h,i,{d,aa,bb,{d,1,2,3,4,5},dd,ee},
-			       k,l},5}, -1)),
+             k,l},5}, -1)),
 
     A = aaaaaaaaaaaaa,
     %% Print the record with dots at the end of the line (Ll = 80).
     "{aaaaaaa" ++ _ =
-	p({A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-								       {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-																 {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-																							   {A,{A,{ggg,{hhh,{ii,{jj,{kk,{ll,{mm,{nn,{oo,{d,1,2,3,4,5}
-																												   }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
-						       }}}}}}}}}}}}}}}}, 146),
+  p({A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                       {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                                 {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                                                 {A,{A,{ggg,{hhh,{ii,{jj,{kk,{ll,{mm,{nn,{oo,{d,1,2,3,4,5}
+                                                           }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+                   }}}}}}}}}}}}}}}}, 146),
     "{aaaaaaa" ++ _ =
-	p({A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-								       {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-																 {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
-																							   {A,{A,{A,{A,{A,{ggg,{hhh,{ii,{jj,{kk,{ll,{mm,{nn,{oo,{a}
-																													    }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
-								}}}}}}}}}}}}}}}}}}}, 152),
+  p({A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                       {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                                 {A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{A,
+                                                 {A,{A,{A,{A,{A,{ggg,{hhh,{ii,{jj,{kk,{ll,{mm,{nn,{oo,{a}
+                                                              }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+                }}}}}}}}}}}}}}}}}}}, 152),
 
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,\n"
-	 "            {aaaaaaaaaaaaa,\n"
-	 "                {aaaaaaaaaaaaa,\n"
-	 "                    {aaaaaaaaaaaaa,\n"
-	 "                        {g,{h,{i,{j,{k,{l,{m,{n,{o,#"
-	 "d{...}}}}}}}}}}}}}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,\n"
+   "            {aaaaaaaaaaaaa,\n"
+   "                {aaaaaaaaaaaaa,\n"
+   "                    {aaaaaaaaaaaaa,\n"
+   "                        {g,{h,{i,{j,{k,{l,{m,{n,{o,#"
+   "d{...}}}}}}}}}}}}}}}}">>,
        p({A,{A,{A,{A,{A,{A,
-			 {g,{h,{i,{j,{k,{l,{m,{n,{o,{d,1,2,3,4,5}}}}}}}}}}}}}}}}, 32)),
+       {g,{h,{i,{j,{k,{l,{m,{n,{o,{d,1,2,3,4,5}}}}}}}}}}}}}}}}, 32)),
     bt(<<"{a,#b{f = {c,{d,{e,{f,...}}}}}}">>,
        p({a,{b,{c,{d,{e,{f,g}}}}}}, 12)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,\n"
-	 "            {aaaaaaaaaaaaa,\n"
-	 "                {aaaaaaaaaaaaa,\n"
-	 "                    {aaaaaaaaaaaaa,\n"
-	 "                        {aaaaaaaaaaaaa,\n"
-	 "                            {aaaaaaaaaaaaa,\n"
-	 "                                {aaaaaaaaaaaaa,#c{f1 = ddd,"
-	 "f2 = eee}}}}}}}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,\n"
+   "            {aaaaaaaaaaaaa,\n"
+   "                {aaaaaaaaaaaaa,\n"
+   "                    {aaaaaaaaaaaaa,\n"
+   "                        {aaaaaaaaaaaaa,\n"
+   "                            {aaaaaaaaaaaaa,\n"
+   "                                {aaaaaaaaaaaaa,#c{f1 = ddd,"
+   "f2 = eee}}}}}}}}}}">>,
        p({A,{A,{A,{A,{A,{A,{A,{A,{A,{c,ddd,eee}}}}}}}}}}, 100)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,{aaaaaaaaaaaaa,{aaaaaaaaaaaaa,...}}}}">>,
+   "    {aaaaaaaaaaaaa,{aaaaaaaaaaaaa,{aaaaaaaaaaaaa,...}}}}">>,
        p({A,{A,{A,{A,{b}}}}}, 8)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,{aaaaaaaaaaaaa,{aaaaaaaaaaaaa,...}}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,{aaaaaaaaaaaaa,{aaaaaaaaaaaaa,...}}}}}">>,
        p({A,{A,{A,{A,{A,{b}}}}}}, 10)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,\n"
-	 "            {aaaaaaaaaaaaa,\n"
-	 "                {aaaaaaaaaaaaa,\n"
-	 "                    {aaaaaaaaaaaaa,\n"
-	 "                        {aaaaaaaaaaaaa,\n"
-	 "                            {aaaaaaaaaaaaa,\n"
-	 "                                {aaaaaaaaaaaaa,"
-	 "{aaaaaaaaaaaaa,#a{}}}}}}}}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,\n"
+   "            {aaaaaaaaaaaaa,\n"
+   "                {aaaaaaaaaaaaa,\n"
+   "                    {aaaaaaaaaaaaa,\n"
+   "                        {aaaaaaaaaaaaa,\n"
+   "                            {aaaaaaaaaaaaa,\n"
+   "                                {aaaaaaaaaaaaa,"
+   "{aaaaaaaaaaaaa,#a{}}}}}}}}}}}">>,
        p({A,{A,{A,{A,{A,{A,{A,{A,{A,{A,{a}}}}}}}}}}}, 23)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,\n",
-	 "            #rrrrr{\n"
-	 "                f1 = kljlkjlksfdgkljlsdkjf,"
-	 "f2 = kljkljsdaflkjlkjsdf,...}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,\n",
+   "            #rrrrr{\n"
+   "                f1 = kljlkjlksfdgkljlsdkjf,"
+   "f2 = kljkljsdaflkjlkjsdf,...}}}}">>,
        p({A,{A,{A,{rrrrr, kljlkjlksfdgkljlsdkjf,
-		   kljkljsdaflkjlkjsdf,
-		   asdfkldsjfklkljsdklfds}}}}, 10)),
+       kljkljsdaflkjlkjsdf,
+       asdfkldsjfklkljsdklfds}}}}, 10)),
     bt(<<"{aaaaaaaaaaaaa,\n"
-	 "    {aaaaaaaaaaaaa,\n"
-	 "        {aaaaaaaaaaaaa,\n"
-	 "            {aaaaaaaaaaaaa,\n"
-	 "                {aaaaaaaaaaaaa,\n"
-	 "                    {aaaaaaaaaaaaa,\n"
-	 "                        {aaaaaaaaaaaaa,\n"
-	 "                            {g,{h,{i,{j,{k,{l,{m,{n,"
-	 "{o,#a{}}}}}}}}}}}}}}}}}">>,
+   "    {aaaaaaaaaaaaa,\n"
+   "        {aaaaaaaaaaaaa,\n"
+   "            {aaaaaaaaaaaaa,\n"
+   "                {aaaaaaaaaaaaa,\n"
+   "                    {aaaaaaaaaaaaa,\n"
+   "                        {aaaaaaaaaaaaa,\n"
+   "                            {g,{h,{i,{j,{k,{l,{m,{n,"
+   "{o,#a{}}}}}}}}}}}}}}}}}">>,
        p({A,{A,{A,{A,{A,{A,{A,
-			    {g,{h,{i,{j,{k,{l,{m,{n,{o,{a}}}}}}}}}}}}}}}}}, 100)),
+          {g,{h,{i,{j,{k,{l,{m,{n,{o,{a}}}}}}}}}}}}}}}}}, 100)),
     bt(<<"#c{\n"
-	 " f1 =\n"
-	 "  #c{\n"
-	 "   f1 =\n"
-	 "    #c{\n"
-	 "     f1 =\n"
-	 "      #c{\n"
-	 "       f1 =\n"
-	 "        #c{\n"
-	 "         f1 =\n"
-	 "          #c{\n"
-	 "           f1 =\n"
-	 "            #c{\n"
-	 "             f1 =\n"
-	 "              #c{\n"
-	 "               f1 =\n"
-	 "                #c{\n"
-	 "                 f1 = #c{f1 = #c{f1 = #c{f1 = a,"
-	 "f2 = b},f2 = b},f2 = b},\n"
-	 "                 f2 = b},\n"
-	 "               f2 = b},\n"
-	 "             f2 = b},\n"
-	 "           f2 = b},\n"
-	 "         f2 = b},\n"
-	 "       f2 = b},\n"
-	 "     f2 = b},\n"
-	 "   f2 = b},\n"
-	 " f2 = b}">>,
+   " f1 =\n"
+   "  #c{\n"
+   "   f1 =\n"
+   "    #c{\n"
+   "     f1 =\n"
+   "      #c{\n"
+   "       f1 =\n"
+   "        #c{\n"
+   "         f1 =\n"
+   "          #c{\n"
+   "           f1 =\n"
+   "            #c{\n"
+   "             f1 =\n"
+   "              #c{\n"
+   "               f1 =\n"
+   "                #c{\n"
+   "                 f1 = #c{f1 = #c{f1 = #c{f1 = a,"
+   "f2 = b},f2 = b},f2 = b},\n"
+   "                 f2 = b},\n"
+   "               f2 = b},\n"
+   "             f2 = b},\n"
+   "           f2 = b},\n"
+   "         f2 = b},\n"
+   "       f2 = b},\n"
+   "     f2 = b},\n"
+   "   f2 = b},\n"
+   " f2 = b}">>,
        p({c,{c,{c,{c,{c,{c,{c,{c,{c,{c,{c,{c,a,b},b},b},b},b},b},
-			 b},b},b},b},b},b}, -1)),
+       b},b},b},b},b},b}, -1)),
     bt(<<"#rrrrr{\n"
-	 " f1 =\n"
-	 "  #rrrrr{\n"
-	 "   f1 =\n"
-	 "    #rrrrr{\n"
-	 "     f1 =\n"
-	 "      #rrrrr{\n"
-	 "       f1 =\n"
-	 "        {rrrrr,{rrrrr,a,#rrrrr{f1 = {rrrrr,1,2},f2 = a,"
-	 "f3 = b}},b},\n"
-	 "       f2 = {rrrrr,c,d},\n"
-	 "       f3 = {rrrrr,1,2}},\n"
-	 "     f2 = 1,f3 = 2},\n"
-	 "   f2 = 3,f3 = 4},\n"
-	 " f2 = 5,f3 = 6}">>,
+   " f1 =\n"
+   "  #rrrrr{\n"
+   "   f1 =\n"
+   "    #rrrrr{\n"
+   "     f1 =\n"
+   "      #rrrrr{\n"
+   "       f1 =\n"
+   "        {rrrrr,{rrrrr,a,#rrrrr{f1 = {rrrrr,1,2},f2 = a,"
+   "f3 = b}},b},\n"
+   "       f2 = {rrrrr,c,d},\n"
+   "       f3 = {rrrrr,1,2}},\n"
+   "     f2 = 1,f3 = 2},\n"
+   "   f2 = 3,f3 = 4},\n"
+   " f2 = 5,f3 = 6}">>,
        p({rrrrr,{rrrrr,{rrrrr,{rrrrr,{rrrrr,{rrrrr,a,{rrrrr,
-						      {rrrrr,1,2},a,b}},b},{rrrrr,c,d},{rrrrr,1,2}},
-			1,2},3,4},5,6}, -1)),
+                  {rrrrr,1,2},a,b}},b},{rrrrr,c,d},{rrrrr,1,2}},
+      1,2},3,4},5,6}, -1)),
     "{aaa,\n {aaa," ++ _ =
         p({aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
-								       {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
-															       {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
-																						  {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
-																												{aaa,a}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}},
+                       {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
+                                     {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
+                                              {aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,{aaa,
+                                                        {aaa,a}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}},
           1, 80, -1),
 
     %% A few other cases...
@@ -599,9 +598,9 @@ otp_6354(Config) when is_list(Config) ->
     "#Fun<" ++ _ = io_lib_pretty:print(fun() -> foo end),
     %% No support for negative columns any more:
     "[a,\n [b,\n  c,\n  d,\n  [e,\n   f]],\n c]" =
-	p([a,[b,c,d,[e,f]],c], -1, 2, 10),
+  p([a,[b,c,d,[e,f]],c], -1, 2, 10),
     "[a,\n [b,\n  c,\n  d,\n  [e,\n   f]],\n c]" =
-	p([a,[b,c,d,[e,f]],c], 0, 2, 10),
+  p([a,[b,c,d,[e,f]],c], 0, 2, 10),
     %% 20 bytes are tried first, then the rest. Try 21 bytes:
     L = lists:duplicate(20, $a),
     %% bt(<<"<<\"aaaaaa\"\n  \"aaaaaa\"\n  \"aaaaaa\"\n  \"aaa\">>">>,
@@ -611,24 +610,24 @@ otp_6354(Config) when is_list(Config) ->
     "<<97," ++ _ = p(list_to_binary(L ++ [3]), 1, 10, 22),
 
     "\"\\b\\t\\n\\v\\f\\r\\e\250\"" =
-	p([8,9,10,11,12,13,27,168], 1, 40, -1),
+  p([8,9,10,11,12,13,27,168], 1, 40, -1),
     %% "\"\\b\\t\\n\"\n \"\\v\\f\\r\"\n \"\\e\250\"" =
     "\"\\b\\t\\n\\v\\f\\r\\e¨\"" =
-	p([8,9,10,11,12,13,27,168], 1, 10, -1),
+  p([8,9,10,11,12,13,27,168], 1, 10, -1),
     "\"\\b\\t\\n\\v\\f\\r\\e\250\"" =
-	p([8,9,10,11,12,13,27,168], 1, 40, 100),
+  p([8,9,10,11,12,13,27,168], 1, 40, 100),
     %% "\"\\e\\t\\nab\"\n \"cd\"" =
     "\"\\e\\t\\nabcd\"" =
-	p("\e\t\nabcd", 1, 12, -1),
+  p("\e\t\nabcd", 1, 12, -1),
 
     %% DEL (127) is special...
     "[127]" = p("\d", 1, 10, -1),
     "[127]" = p([127], 1, 10, 100),
 
     "<<\"\\b\\t\\n\\v\\f\\r\\e\250\">>" =
-	p(<<8,9,10,11,12,13,27,168>>, 1, 40, -1),
+  p(<<8,9,10,11,12,13,27,168>>, 1, 40, -1),
     "<<\"\\b\\t\\n\\v\\f\\r\\e\250\">>" =
-	p(<<8,9,10,11,12,13,27,168>>, 1, 10, -1),
+  p(<<8,9,10,11,12,13,27,168>>, 1, 10, -1),
     "<<127>>" = p(<<127>>, 1, 10, 100),
 
     %% "Partial" string binaries:
@@ -640,26 +639,26 @@ otp_6354(Config) when is_list(Config) ->
     "<<3,104,...>>" = p(list_to_binary([3] ++ "he"), 1, 80, 3),
 
     "<<\"12345678901234567890\"...>>" =
-	p(list_to_binary("12345678901234567890"++[3]), 1, 80, 8),
+  p(list_to_binary("12345678901234567890"++[3]), 1, 80, 8),
     "<<\"12345678901234567890\"...>>" =
-	p(list_to_binary("12345678901234567890"++[3]), 1, 80, 21),
+  p(list_to_binary("12345678901234567890"++[3]), 1, 80, 21),
     "<<49," ++ _ =
-	p(list_to_binary("12345678901234567890"++[3]), 1, 80, 22),
+  p(list_to_binary("12345678901234567890"++[3]), 1, 80, 22),
 
     "{sdfsdfj,\n    23" ++ _ =
-	p({sdfsdfj,23423423342.23432423}, 1, 17, -1),
+  p({sdfsdfj,23423423342.23432423}, 1, 17, -1),
 
     bt(<<"kljkljlksdjjlf kljalkjlsdajafasjdfj [kjljklasdf,kjlljsfd,sdfsdkjfsd,kjjsdf,jl,
                                      lkjjlajsfd|jsdf]">>,
-             fmt("~w ~w ~p", 
+             fmt("~w ~w ~p",
                  [kljkljlksdjjlf,
                   kljalkjlsdajafasjdfj,
-                  [kjljklasdf,kjlljsfd,sdfsdkjfsd,kjjsdf,jl,lkjjlajsfd | 
+                  [kjljklasdf,kjlljsfd,sdfsdkjfsd,kjjsdf,jl,lkjjlajsfd |
                    jsdf]])),
 
     %% Binaries are split as well:
     bt(<<"<<80,100,0,55,55,55,55,55,55,55,55,55,\n  "
-               "55,55,55,55,55,55,55,...>>">>, 
+               "55,55,55,55,55,55,55,...>>">>,
              p(<<80,100,0,55,55,55,55,55,55,55,55,55,55,55,55,55,55,55,
                  55,55,55,55,55,55,55,55,55,55,55,55>>,1,40,20)),
     bt(<<"<<80,100,0,55,55,55,55,55,55,55,55,55,\n  "
@@ -730,7 +729,7 @@ rp(Term, Col, Ll, D, RF) ->
 rp(Term, Col, Ll, D, M, none) ->
     rp(Term, Col, Ll, D, M, fun(_, _) -> no end);
 rp(Term, Col, Ll, D, M, RF) ->
-    %% io:format("~n~n*** Col = ~p Ll = ~p D = ~p~n~p~n-->~n", 
+    %% io:format("~n~n*** Col = ~p Ll = ~p D = ~p~n~p~n-->~n",
     %%           [Col, Ll, D, Term]),
     R = io_lib_pretty:print(Term, Col, Ll, D, M, RF),
     %% io:format("~s~n<--~n", [R]),
@@ -844,11 +843,11 @@ otp_6708(Config) when is_list(Config) ->
                 jklsdjfklsd, masdfjkkl}, -1)),
     bt(<<"#b{f = {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,\n"
                "                    kjdd}}">>,
-             p({b, {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,kjdd}}, 
+             p({b, {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,kjdd}},
                -1)),
     bt(<<"#b{f = {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,\n"
                "                    kdd}}">>,
-             p({b, {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,kdd}}, 
+             p({b, {lkjljalksdf,jklaskfjd,kljasdlf,kljasdf,kljsdlkf,kdd}},
                -1)),
     bt(<<"#e{f = undefined,g = undefined,\n"
                "   h = #e{f = 11,g = 22,h = 333}}">>,
@@ -860,7 +859,7 @@ otp_6708(Config) when is_list(Config) ->
                " 23,\n"
                " {{abadalkjlasdjflksdajfksdklfsdjlkfdlskjflsdj"
                         "flsdjfldsdsdddd}}]">>,
-          p(lists:seq(1,23) ++ 
+          p(lists:seq(1,23) ++
             [{{abadalkjlasdjflksdajfksdklfsdjlkfdlskjflsdjflsdjfldsdsdddd}}],
             -1)),
     bt(<<"{lkjasdf,\n"
@@ -949,10 +948,10 @@ otp_7084(Config) when is_list(Config) ->
          {g_choice, fun g_choice/0},
          {g_misc, fun g_misc/0}],
     F = fun({M,T}) -> io:format("~p~n", [M]), T() end,
-    R = try 
+    R = try
             lists:foreach(fun(T) -> F(T) end, L),
             ok
-        catch throw:Reason -> 
+        catch throw:Reason ->
             Reason
         end,
     R.
@@ -992,7 +991,7 @@ g_denormalized() ->
     [ft({{S,0,?ONE(N)},D,D}) || S <- [0,1], N <- lists:seq(0, 52)],
     ok.
 
-g_normalized() -> 
+g_normalized() ->
     %% Normalized floats (exponent carry):
 %%    D = 5,
     %% Faster:
@@ -1010,7 +1009,7 @@ g_choice() ->
     lists:foreach(fun(V) -> g_t(V) end, L),
     ok.
 
-g_misc() -> 
+g_misc() ->
     L_0_308 = lists:seq(0, 308),
     L_0_307 = lists:seq(0, 307),
 
@@ -1098,16 +1097,16 @@ g_t_1(V, Sv) ->
     %% to V than Sv, but such that when reading SvMinus (SvPlus) wrong
     %% float would be returned.
     case rat_lte(Abs_Sv_Vr, Svminus_Vr) of
-        true -> 
+        true ->
             ok;
-        false ->  
+        false ->
              case list_to_float(SvMinus) of
                  V -> throw(vsminus_too_close_to_v);
                  _Vminus -> ok
              end
     end,
     case rat_lte(Abs_Sv_Vr, Svplus_Vr) of
-        true -> 
+        true ->
             ok;
         false ->
              case list_to_float(SvPlus) of
@@ -1121,7 +1120,7 @@ g_t_1(V, Sv) ->
     %%       that |V - Sv| =< (V+ - V)
     %% (An alternative is  V- + V =< 2*Sv =< V + V+.)
     case inc(V) of
-        inf -> 
+        inf ->
             ok;
         Vplus ->
             Vplusr = f2r(Vplus),
@@ -1176,7 +1175,7 @@ g_t_1(V, Sv) ->
 
     ok.
 
-%%% In "123450000.0", '5' is the lsd; 
+%%% In "123450000.0", '5' is the lsd;
 %%% in "1234.0000", (the last) '0' is the lsd;
 %%% in "1234.0", '4' is the lsd (the Erlang syntax requires the final zero).
 
@@ -1212,7 +1211,7 @@ step_lsd(Ds, N) when N < 0 ->
 %% Increments or decrements the least significant digit.
 incr_lsd("-"++Ds, I) ->
     "-"++incr_lsd(Ds, I);
-incr_lsd(Ds, I) when I =:= 1; I =:= -1 -> 
+incr_lsd(Ds, I) when I =:= 1; I =:= -1 ->
     [MS|E] = string:tokens(Ds, "eE"),
     X = ["e" || true <- [E =/= []]],
     lists:flatten([incr_lsd0(lists:reverse(MS), I, []), X, E]).
@@ -1245,7 +1244,7 @@ s2r(S) when is_list(S) ->
         [MS, ES] ->
             Mr = s10(MS),
             E = list_to_integer(ES),
-            if 
+            if
                 E < 0 ->
                     rat_multiply(Mr, {1,pow10(-E)});
                 true ->
@@ -1289,7 +1288,7 @@ dec({S,BE,M}) when 0 =< S, S =< 1,
     <<F1:64/float>> = <<S1:1, BE1:11, M1:52>>,
     true = F1 < F,
     F1.
-    
+
 
 dec1(0, 0, 0) ->
     dec1(1, 0, 0);
@@ -1389,12 +1388,12 @@ rat_normalize({T,N}) when N =/= 0 ->
     N2 = N div G,
     if
         T2 < 0 ->
-            if 
+            if
                 N2 < 0 -> {-T2,-N2};
                 true -> {T2,N2}
             end;
         true ->
-            if 
+            if
                 N2 < 0 -> {-T2,-N2};
                 true -> {T2,N2}
             end
@@ -1456,7 +1455,7 @@ g_choice(S) when is_list(S) ->
             end;
         Pre =:= 0, Post =:= 0, El > 0 ->   % D.DDDeDD
             E = list_to_integer(ES),
-            if 
+            if
                 E >= 0 ->
                     Cost = E - (Fl - 1);
                 E < 0 ->
@@ -1533,10 +1532,10 @@ do_collect_line_2(Part1, Part2) ->
 
 do_collect_line_3(State0, [H|T], Dummy) ->
     case io_lib:collect_line(State0, H, Dummy) of
-	{stop,Line,Rest} ->
-	    {stop,Line,do_collect_line_adjust_rest(Rest, T)};
-	State ->
-	    do_collect_line_3(State, T, Dummy)
+  {stop,Line,Rest} ->
+      {stop,Line,do_collect_line_adjust_rest(Rest, T)};
+  State ->
+      do_collect_line_3(State, T, Dummy)
     end.
 
 do_collect_line_adjust_rest(eof, []) -> eof;
@@ -1569,10 +1568,10 @@ io_fread_newlines(Config) when is_list(Config) ->
     F9 = [[0],[1],[2],[3],[4],[5],[6],[7],[8],[9]],
     Newlines = ["\n", "\r\n", "\r"],
     try
-	io_fread_newlines_1([F0,F1,F2,F3,F4,F5,F6,F7,F8,F9],
-				  Fname, Newlines)
+  io_fread_newlines_1([F0,F1,F2,F3,F4,F5,F6,F7,F8,F9],
+          Fname, Newlines)
     after
-	file:delete(Fname)
+  file:delete(Fname)
     end.
 
 io_fread_newlines_1(Fs, Fname, [Newline|Newlines]) ->
@@ -1610,21 +1609,21 @@ digit_line([D|Ds]) ->
 read_newlines_file(Fname) ->
     {ok,Fd} = file:open(Fname, [read]),
     try {L, N0} = R0 = read_newlines(Fd, [], 0),
-	case io:fread(Fd, "", "~*s~l") of
-	    eof -> R0;
-	    {ok,[N]} -> {L,N0+N}
-	end
+  case io:fread(Fd, "", "~*s~l") of
+      eof -> R0;
+      {ok,[N]} -> {L,N0+N}
+  end
     after
-	file:close(Fd)
+  file:close(Fd)
     end.
-    
+
 
 read_newlines(Fd, Acc, N0) ->
     case io:fread(Fd, "", "~d~l") of
-	{ok,[D,N]} ->
-	    read_newlines(Fd, [D|Acc], N0+N);
-	eof ->
-	    {lists:reverse(Acc),N0}
+  {ok,[D,N]} ->
+      read_newlines(Fd, [D|Acc], N0+N);
+  eof ->
+      {lists:reverse(Acc),N0}
     end.
 
 
@@ -1734,56 +1733,56 @@ io_lib_fread_literal(Suite) when is_list(Suite) ->
 printable_range(Suite) when is_list(Suite) ->
     Pa = filename:dirname(code:which(?MODULE)),
     {ok, UNode} = test_server:start_node(printable_range_unicode, slave,
-					 [{args, " +pc unicode -pa " ++ Pa}]),
+           [{args, " +pc unicode -pa " ++ Pa}]),
     {ok, LNode} = test_server:start_node(printable_range_latin1, slave,
-					 [{args, " +pc latin1 -pa " ++ Pa}]),
+           [{args, " +pc latin1 -pa " ++ Pa}]),
     {ok, DNode} = test_server:start_node(printable_range_default, slave,
-					 [{args, " -pa " ++ Pa}]),
+           [{args, " -pa " ++ Pa}]),
     unicode = rpc:call(UNode,io,printable_range,[]),
     latin1 = rpc:call(LNode,io,printable_range,[]),
     latin1 = rpc:call(DNode,io,printable_range,[]),
     test_server:stop_node(UNode),
     test_server:stop_node(LNode),
     {ok, UNode} = test_server:start_node(printable_range_unicode, slave,
-					 [{args, " +pcunicode -pa " ++ Pa}]),
+           [{args, " +pcunicode -pa " ++ Pa}]),
     {ok, LNode} = test_server:start_node(printable_range_latin1, slave,
-					 [{args, " +pclatin1 -pa " ++ Pa}]),
+           [{args, " +pclatin1 -pa " ++ Pa}]),
     unicode = rpc:call(UNode,io,printable_range,[]),
     latin1 = rpc:call(LNode,io,printable_range,[]),
     PrettyOptions = [{column,1},
-		     {line_length,109},
-		     {depth,30},
-		     {line_max_chars,60},
-		     {record_print_fun,
-		      fun(_,_) -> no end},
-		     {encoding,unicode}],
+         {line_length,109},
+         {depth,30},
+         {line_max_chars,60},
+         {record_print_fun,
+          fun(_,_) -> no end},
+         {encoding,unicode}],
     PrintableControls = "\t\v\b\f\e\r\n",
 
     1025 = print_max(UNode, [{hello, [1024,1025]},
-			     PrettyOptions]),
+           PrettyOptions]),
     125 = print_max(LNode,  [{hello, [1024,1025]},
-			     PrettyOptions]),
+           PrettyOptions]),
     125 = print_max(DNode,  [{hello, [1024,1025]},
-			     PrettyOptions]),
+           PrettyOptions]),
     1025 = print_max(UNode, [{hello, <<1024/utf8,1025/utf8>>},
-			     PrettyOptions]),
+           PrettyOptions]),
     125 = print_max(LNode,  [{hello, <<1024/utf8,1025/utf8>>},
-			     PrettyOptions]),
+           PrettyOptions]),
     125 = print_max(DNode,  [{hello, <<1024/utf8,1025/utf8>>},
-			     PrettyOptions]),
+           PrettyOptions]),
     $v = print_max(UNode, [PrintableControls,PrettyOptions]),
     $v = print_max(LNode, [PrintableControls,PrettyOptions]),
     $v = print_max(DNode, [PrintableControls,PrettyOptions]),
     16#10FFFF = print_max(UNode,
-			  [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
-			   PrettyOptions]),
+        [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
+         PrettyOptions]),
     $> = print_max(LNode,
-		   [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
-		    PrettyOptions]),
+       [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
+        PrettyOptions]),
     $> = print_max(DNode,
-		   [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
-		    PrettyOptions]),
-    
+       [<<16#10FFFF/utf8,"\t\v\b\f\e\r\n">>,
+        PrettyOptions]),
+
     1025 = format_max(UNode, ["~tp", [{hello, [1024,1025]}]]),
     125 = format_max(LNode,  ["~tp", [{hello, [1024,1025]}]]),
     125 = format_max(DNode,  ["~tp", [{hello, [1024,1025]}]]),
@@ -1828,9 +1827,9 @@ bad_printable_range(Config) when is_list(Config) ->
 
 flush_from_port(P) ->
     receive {P, _} ->
-	    flush_from_port(P)
+      flush_from_port(P)
     after 0 ->
-	    ok
+      ok
     end.
 
 %% Test binaries printed with a depth of one behave correctly.
@@ -1847,15 +1846,15 @@ io_lib_print_binary_depth_one(Suite) when is_list(Suite) ->
 otp_10302(Suite) when is_list(Suite) ->
     Pa = filename:dirname(code:which(?MODULE)),
     {ok, UNode} = test_server:start_node(printable_range_unicode, slave,
-					 [{args, " +pc unicode -pa " ++ Pa}]),
+           [{args, " +pc unicode -pa " ++ Pa}]),
     {ok, LNode} = test_server:start_node(printable_range_latin1, slave,
-					 [{args, " +pc latin1 -pa " ++ Pa}]),
+           [{args, " +pc latin1 -pa " ++ Pa}]),
     "\"\x{400}\"" = rpc:call(UNode,?MODULE,pretty,["\x{400}", -1]),
     "<<\"\x{400}\"/utf8>>" = rpc:call(UNode,?MODULE,pretty,
-				      [<<"\x{400}"/utf8>>, -1]),
+              [<<"\x{400}"/utf8>>, -1]),
 
     "<<\"\x{400}foo\"/utf8>>" = rpc:call(UNode,?MODULE,pretty,
-					 [<<"\x{400}foo"/utf8>>, 2]),
+           [<<"\x{400}foo"/utf8>>, 2]),
     "[1024]" = rpc:call(LNode,?MODULE,pretty,["\x{400}", -1]),
     "<<208,128>>" = rpc:call(LNode,?MODULE,pretty,[<<"\x{400}"/utf8>>, -1]),
 
@@ -1983,14 +1982,14 @@ io_lib_width_too_small(_Config) ->
 %% significantly slower than with an empty message queue.
 io_with_huge_message_queue(Config) when is_list(Config) ->
     case {test_server:is_native(gen),test_server:is_cover()} of
-	{true,_} ->
-	    {skip,
-	     "gen is native - huge message queue optimization "
-	     "is not implemented"};
-	{_,true} ->
-	    {skip,"Running under cover"};
-	{false,false} ->
-	    do_io_with_huge_message_queue(Config)
+  {true,_} ->
+      {skip,
+       "gen is native - huge message queue optimization "
+       "is not implemented"};
+  {_,true} ->
+      {skip,"Running under cover"};
+  {false,false} ->
+      do_io_with_huge_message_queue(Config)
     end.
 
 do_io_with_huge_message_queue(Config) ->
@@ -1998,9 +1997,9 @@ do_io_with_huge_message_queue(Config) ->
     File = filename:join(PrivDir, "slask"),
     {ok, F1} = file:open(File, [write]),
     Test = fun(Times) ->
-		   {Time,ok} = timer:tc(fun() -> writes(Times, F1) end),
-		   Time
-	   end,
+       {Time,ok} = timer:tc(fun() -> writes(Times, F1) end),
+       Time
+     end,
     {Times,EmptyTime} = calibrate(100, Test),
 
     [self() ! {msg,N} || N <- lists:seq(1, 500000)],
@@ -2013,11 +2012,11 @@ do_io_with_huge_message_queue(Config) ->
     io:format("Time for huge message queue: ~p", [FullTime]),
 
     case (FullTime+1) / (EmptyTime+1) of
-	Q when Q < 10 ->
-	    ok;
-	Q ->
-	    io:format("Q = ~p", [Q]),
-	    ct:fail(failed)
+  Q when Q < 10 ->
+      ok;
+  Q ->
+      io:format("Q = ~p", [Q]),
+      ct:fail(failed)
     end,
     ok.
 
@@ -2025,10 +2024,10 @@ do_io_with_huge_message_queue(Config) ->
 %% test case to fail.
 calibrate(N, Test) when N =< 100000 ->
     case Test(N) of
-	Time when Time < 50000 ->
-	    calibrate(10*N, Test);
-	Time ->
-	    {N,Time}
+  Time when Time < 50000 ->
+      calibrate(10*N, Test);
+  Time ->
+      {N,Time}
     end;
 calibrate(N, _) ->
     N.
@@ -2058,17 +2057,17 @@ maps(_Config) ->
     "#{}" = fmt("~w", [#{}]),
     "#{a => b}" = fmt("~w", [#{a=>b}]),
     re_fmt(<<"#\\{(a => b),[.][.][.]\\}">>,
-	     "~W", [#{a => b,c => d},2]),
+       "~W", [#{a => b,c => d},2]),
     re_fmt(<<"#\\{(a => b),[.][.][.]\\}">>,
-	   "~W", [#{a => b,c => d,e => f},2]),
+     "~W", [#{a => b,c => d,e => f},2]),
 
     "#{}" = fmt("~p", [#{}]),
     "#{a => b}" = fmt("~p", [#{a => b}]),
     "#{...}" = fmt("~P", [#{a => b},1]),
     re_fmt(<<"#\\{(a => b|c => d),[.][.][.]\\}">>,
-	   "~P", [#{a => b,c => d},2]),
+     "~P", [#{a => b,c => d},2]),
     re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
-	   "~P", [#{a => b,c => d,e => f},2]),
+     "~P", [#{a => b,c => d,e => f},2]),
 
     List = [{I,I*I} || I <- lists:seq(1, 20)],
     Map = maps:from_list(List),
@@ -2088,12 +2087,12 @@ maps(_Config) ->
 re_fmt(Pattern, Format, Args) ->
     S = list_to_binary(fmt(Format, Args)),
     case re:run(S, Pattern, [{capture,none}]) of
-	nomatch ->
-	    io:format("Pattern: ~s", [Pattern]),
-	    io:format("Result:  ~s", [S]),
-	    ct:fail(failed);
-	match ->
-	    ok
+  nomatch ->
+      io:format("Pattern: ~s", [Pattern]),
+      io:format("Result:  ~s", [S]),
+      ct:fail(failed);
+  match ->
+      ok
     end.
 
 %% Parse a map consisting of integer keys and values.
@@ -2109,12 +2108,12 @@ parse_map_1(S0) ->
     S2 = parse_expect(S1, "=>"),
     {Val,S3} = parse_number(S2),
     case S3 of
-	","++S4 ->
-	    S5 = parse_skip_ws(S4),
-	    {Map,S} = parse_map_1(S5),
-	    {Map#{Key=>Val},S};
-	S ->
-	    {#{Key=>Val},S}
+  ","++S4 ->
+      S5 = parse_skip_ws(S4),
+      {Map,S} = parse_map_1(S5),
+      {Map#{Key=>Val},S};
+  S ->
+      {#{Key=>Val},S}
     end.
 
 parse_number(S) ->
@@ -2122,9 +2121,9 @@ parse_number(S) ->
 
 parse_number([C|S], Acc0) when $0 =< C, C =< $9 ->
     Acc = case Acc0 of
-	      none -> 0;
-	      _ when is_integer(Acc0) -> Acc0
-	  end,
+        none -> 0;
+        _ when is_integer(Acc0) -> Acc0
+    end,
     parse_number(S, Acc*10+C-$0);
 parse_number(S, Acc) ->
     {Acc,parse_skip_ws(S)}.
@@ -2251,7 +2250,7 @@ otp_14175(_Config) ->
        "      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz}", p(M3, -1)),
 
     R4 = {c,{c,{c,{c,{c,{c,{c,{c,{c,{c,{c,{c,a,b},b},b},b},b},b},
-			 b},b},b},b},b},b},
+       b},b},b},b},b},b},
     M4 = #{aaaaaaaaaaaaaaaaaaaa => R4,
            bbbbbbbbbbbbbbbbbbbb => R4,
            cccccccccccccccccccc => R4,
@@ -2512,7 +2511,7 @@ trunc_string() ->
     "str ..." = trf("str ~8s", ["str1"], 6),
     Pa = filename:dirname(code:which(?MODULE)),
     {ok, UNode} = test_server:start_node(printable_range_unicode, slave,
-					 [{args, " +pc unicode -pa " ++ Pa}]),
+           [{args, " +pc unicode -pa " ++ Pa}]),
     U = "кирилли́ческий атом",
     UFun = fun(Format, Args, CharsLimit) ->
                    rpc:call(UNode,


### PR DESCRIPTION
This pull request includes otp 23, patches we always carry, and an additional patch that solves an issue related to the distribution protocol and 'creation' values. 

The distribution protocol changed in 23 and for some reason there's a persistent issue where the internal function erts_internal:get_creation/0 is returning undefined which is then put into part of the binary protocol. Since we don't actually care about the creation value, it seems OK to just return 0, and the protocol continues on as expected. 

Beyond that there are some changes that need to happen in ns_server otherwise some features will not work (specifically, node-to-node encryption).