### PR TITLE
MB-52898: Set timeout=5000 for ssl:connect in tls dist proxy

### DIFF
--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -283,8 +283,13 @@ try_connect(Port) ->
 setup_proxy(Driver, Ip, Port, ExtraOpts, Parent) ->
     process_flag(trap_exit, true),
     Opts = connect_options(ExtraOpts ++ get_ssl_options(client)),
+    Timeout = try
+                  list_to_integer(os:getenv("ERL_TLS_DIST_CONNECT_TIMEOUT"))
+              catch
+                  _:_ -> 5000
+              end,
     case ssl:connect(Ip, Port, [{active, true}, binary, {packet,?PPRE}, nodelay(),
-                                Driver:family()] ++ Opts) of
+                                Driver:family()] ++ Opts, Timeout) of
 	{ok, World} ->
 	    {ok, ErtsL} = gen_tcp:listen(0, [{active, true}, {ip, loopback}, binary, {packet,?PPRE}]),
 	    {ok, #net_address{address={_,LPort}}} = get_tcp_address(ErtsL),


### PR DESCRIPTION
If some node's IP doesn't reply to tcp SYN, ssl:connect in tls dist proxy will hang for 127 seconds. It leads to accumulation of {connect, ...} messages in the dist proxy mailbox (because net_kernel retries every 7 seconds). In order to work around this behavior we set connect timeout to 5000 in tls dist proxy.

This patch only makes sense for erlang versions <= 20 where tls_dist_proxy exists.