### PR TITLE
MB-53513: Add post_setup callback to inet_tls_dist for tls keylog

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -449,6 +449,10 @@ do_accept(
 	{AcceptPid, controller} ->
             erlang:demonitor(MRef, [flush]),
             {ok, SslSocket} = tls_sender:dist_tls_socket(DistCtrl),
+            case application:get_env(kernel, cb_dist_post_tls_setup) of
+                {ok, PostTls_Setup} -> PostTls_Setup(SslSocket, server);
+                _ -> ok
+            end,
 	    Timer = dist_util:start_timer(SetupTime),
             NewAllowed = allowed_nodes(SslSocket, Allowed),
             HSData0 = hs_data_common(SslSocket),
@@ -591,6 +595,10 @@ do_setup_connect(Driver, Kernel, Node, Address, Ip, TcpPort, Version, Type, MyNo
         net_kernel:connecttime()) of
     {ok, #sslsocket{pid = [_, DistCtrl| _]} = SslSocket} ->
             _ = monitor_pid(DistCtrl),
+            case application:get_env(kernel, cb_dist_post_tls_setup) of
+                {ok, PostTls_Setup} -> PostTls_Setup(SslSocket, client);
+                _ -> ok
+            end,
             ok = ssl:controlling_process(SslSocket, self()),
             HSData0 = hs_data_common(SslSocket),
         HSData =


### PR DESCRIPTION
In order to enable logging tls keys on client connection in cb_dist, we need access to the SSL socket, which is accessed from inet_tls_dist via net_kernel.