### PR TITLE
[MB-53810] Don't allow any dist connection if cookie is nocookie

### DIFF
--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -137,6 +137,7 @@ handshake_other_started(#hs_data{request_type=ReqType}=HSData0) ->
 	    [Node, HSData#hs_data.other_version]}),
     mark_pending(HSData),
     {MyCookie,HisCookie} = get_cookies(Node),
+    make_sure_cookie_is_set(MyCookie, Node),
     ChallengeA = gen_challenge(),
     send_challenge(HSData, ChallengeA),
     reset_timer(HSData#hs_data.timer),
@@ -148,6 +149,12 @@ handshake_other_started(#hs_data{request_type=ReqType}=HSData0) ->
 handshake_other_started(OldHsData) when element(1,OldHsData) =:= hs_data ->
     handshake_other_started(convert_old_hsdata(OldHsData)).
 
+make_sure_cookie_is_set(nocookie, RemoteNode) ->
+    error_msg("** Connection attempt to/from node ~w rejected."
+              " Cookie is not set. **~n", [RemoteNode]),
+    ?shutdown2(RemoteNode, nocookie);
+make_sure_cookie_is_set(_, _) ->
+    ok.
 
 %%
 %% check if connecting node is allowed to connect
@@ -327,6 +334,7 @@ handshake_we_started(#hs_data{request_type=ReqType,
     check_dflags(NewHSData),
     MyChallenge = gen_challenge(),
     {MyCookie,HisCookie} = get_cookies(Node),
+    make_sure_cookie_is_set(MyCookie, Node),
     send_challenge_reply(NewHSData,MyChallenge,
 			 gen_digest(ChallengeA,HisCookie)),
     reset_timer(NewHSData#hs_data.timer),


### PR DESCRIPTION
I also modified it to use the fact that MyCookie=HisCookie and is just 'Cookie' for all. I am not sure if you will agree with this choice, but I think they are equivalent, and the newer versions all just use 'Cookie'.. 

I am opening this BEFORE I can test it.. I am having some issue building mad-hatter (with, or without this change). So I am trying to confirm ASAP. 

@timofey-barmin 