### PR TITLE
MB-55515: Set default eunit timeout to 60 seconds.

### DIFF
--- a/lib/eunit/src/eunit_internal.hrl
+++ b/lib/eunit/src/eunit_internal.hrl
@@ -26,7 +26,7 @@
 -define(DEFAULT_EXPORT_SUFFIX, "_exported_").
 -define(DEFAULT_TESTMODULE_SUFFIX, "_tests").
 -define(DEFAULT_GROUP_TIMEOUT, infinity).
--define(DEFAULT_TEST_TIMEOUT, 5000).
+-define(DEFAULT_TEST_TIMEOUT, 60000).
 -define(DEFAULT_SETUP_PROCESS, spawn).
 -define(DEFAULT_MODULE_WRAPPER_NAME, eunit_wrapper_).
 


### PR DESCRIPTION
This will allow us to more easily run tests in parallel if we don't have to worry about hitting a 5 second timeout in any slightly long running test.