### PR TITLE
eldap: Add log level to logging in LDAP

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -501,10 +501,10 @@ try_connect([Host|Hosts], Data) ->
     try do_connect(Host, Data, TcpOpts) of
 	{ok,Fd} -> {ok,Data#eldap{host = Host, fd   = Fd}};
 	Err    ->
-	    log2(Data, "Connect: ~p failed ~p~n",[Host, Err]),
+	    log1(Data, "Connect: ~p failed ~p~n",[Host, Err]),
 	    try_connect(Hosts, Data)
     catch _:Err ->
-	    log2(Data, "Connect: ~p failed ~p~n",[Host, Err]),
+	    log1(Data, "Connect: ~p failed ~p~n",[Host, Err]),
 	    try_connect(Hosts, Data)
     end;
 try_connect([],_) ->
@@ -1148,7 +1148,7 @@ v_attributes(Attrs) ->
 %%% Log routines. Call a user provided log routine F.
 %%% --------------------------------------------------------------------
 
-%log1(Data, Str, Args) -> log(Data, Str, Args, 1).
+log1(Data, Str, Args) -> log(Data, Str, Args, 1).
 log2(Data, Str, Args) -> log(Data, Str, Args, 2).
 
 log(Data, Str, Args, Level) when is_function(Data#eldap.log) ->


### PR DESCRIPTION
Erlang library, eldap, can accept a logging function with three parameters: Level, FormatString, Args.
(https://www.erlang.org/doc/man/eldap.html#open-1) The first parameter, Level, is always set to 2.

Here we have added (uncommented) a simple function to log with Level 1 in order to distinguish between error logs and debug logs. At the same time logging errors will call this new function, so we can throttle the ones we have no interest in.